### PR TITLE
Multi-strategy sim, value-trap filter, turnaround signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Daily Japan-equity value screener and paper-trading simulator.
 
 The pipeline pulls financial reports from EDINET, parses XBRL, ingests
 into Postgres, pulls daily prices from JQuants, ranks stocks by the
-**net-cash ratio** `(流動資産 − 有利子負債 + 0.7 × 投資有価証券) ÷ 時価総額`
-(a market-cap-based version of the canonical Japanese
-ネットキャッシュ比率), and runs an equal-weight top-N paper portfolio
+**net-cash ratio** `(流動資産 − 負債合計 + 0.7 × 投資有価証券) ÷ 時価総額`
+(a market-cap-based, conservative form — uses total liabilities, not
+just interest-bearing debt; see `screening/metrics.py` for the
+empirical justification), and runs an equal-weight top-N paper portfolio
 that rebalances daily with a strict-improvement swap rule against a
 TOPIX (`1306.T`) buy-and-hold benchmark.
 

--- a/airflow/dags/paper_trading_sim_dag.py
+++ b/airflow/dags/paper_trading_sim_dag.py
@@ -1,9 +1,10 @@
-"""Daily paper-trading simulation: rebalance the portfolio on the run
-date using that day's screen output.
+"""Daily multi-strategy paper-trading simulation. Each registered
+Strategy maintains its own portfolio against the same screen output.
 
 Sim is path-dependent (day N reads day N-1 positions), so this DAG is
 strictly serial: depends_on_past=True, max_active_runs=1. The first
-task deletes the run date's outputs so re-runs are idempotent.
+task deletes the run date's outputs (per-strategy) so re-runs are
+idempotent.
 """
 
 from __future__ import annotations
@@ -21,9 +22,9 @@ logger = logging.getLogger(__name__)
 
 @dag(
     dag_id="paper_trading_sim_dag",
-    description="Equal-weight top-N net-cash-ratio paper portfolio.",
+    description="Multi-strategy paper portfolio against the net-cash-ratio screen.",
     start_date=datetime(2025, 4, 1, tzinfo=JST),
-    schedule="0 19 * * 1-5",  # 19:00 JST weekdays — after value_screen
+    schedule="0 19 * * 1-5",
     catchup=True,
     max_active_runs=1,
     default_args={
@@ -36,7 +37,7 @@ logger = logging.getLogger(__name__)
 )
 def paper_trading_sim_dag():
     @task
-    def rebalance(data_interval_start=None) -> dict:
+    def rebalance_all(data_interval_start=None) -> dict:
         import pandas as pd
         from sqlalchemy import text
 
@@ -47,105 +48,110 @@ def paper_trading_sim_dag():
             generate_trades,
             select_target_names,
         )
+        from stock_screening.simulation.strategies import STRATEGIES
 
         run_date = data_interval_start.date()
         engine = db.get_engine()
 
-        portfolio.delete_outputs_for_date(engine, run_date)
-
-        prev = portfolio.load_previous_snapshot(engine, run_date)
-
         with engine.connect() as conn:
-            qual = pd.read_sql(
+            qrows = conn.execute(
                 text(
                     'SELECT "secCode" AS sec_code, ratio FROM t_screen_results '
-                    "WHERE run_date = :d AND qualifies = TRUE "
-                    "ORDER BY ratio DESC"
+                    "WHERE run_date = :d AND qualifies = TRUE ORDER BY ratio DESC"
                 ),
-                conn,
-                params={"d": run_date},
-            )
+                {"d": run_date},
+            ).fetchall()
+        qual = pd.DataFrame(qrows, columns=["sec_code", "ratio"])
+        if not qual.empty:
+            qual["ratio"] = qual["ratio"].astype(float)
+        ratios = dict(zip(qual["sec_code"], qual["ratio"], strict=True)) if not qual.empty else {}
 
-        if qual.empty:
-            logger.warning("no qualifying names on %s; carrying prior state", run_date)
-            qual = pd.DataFrame(columns=["sec_code", "ratio"])
-
-        if prev is None:
-            cash = float(config.initial_capital())
-            current_positions = pd.DataFrame(
-                columns=["secCode", "shares", "avg_cost", "last_price", "market_value"]
-            )
-            sim_start_date = run_date
-        else:
-            current_positions = prev.positions
-            cash = prev.cash
-            sim_start_date = _sim_start_date(engine) or run_date
-
-        all_names = sorted(set(qual["sec_code"]) | set(current_positions["secCode"]))
-        prices = portfolio.fetch_prices(engine, run_date, all_names)
         bench = config.benchmark_ticker()
-        if bench not in prices:
-            prices.update(portfolio.fetch_prices(engine, run_date, [bench]))
+        results: dict[str, dict] = {}
 
-        marked = portfolio.mark_to_market(current_positions, prices)
-        nav_pre = cash + (
-            float(marked["market_value"].sum()) if not marked.empty else 0.0
-        )
+        for strategy in STRATEGIES:
+            portfolio.delete_outputs_for_date(engine, run_date, strategy.name)
+            prev = portfolio.load_previous_snapshot(engine, run_date, strategy.name)
 
-        target_names = select_target_names(
-            qual, list(marked["secCode"]) if not marked.empty else [], config.max_positions()
-        )
-        target_shares = compute_target_shares(
-            target_names, prices, nav_pre, config.max_positions()
-        )
+            if prev is None:
+                cash = float(strategy.initial_capital)
+                current_positions = pd.DataFrame(
+                    columns=["secCode", "shares", "avg_cost", "last_price", "market_value"]
+                )
+                sim_start_date = run_date
+            else:
+                current_positions = prev.positions
+                cash = prev.cash
+                sim_start_date = _sim_start_date(engine, strategy.name) or run_date
 
-        current_shares = (
-            {row.secCode: int(row.shares) for row in marked.itertuples()}
-            if not marked.empty
-            else {}
-        )
-        trades = generate_trades(
-            current_shares, target_shares, prices, config.transaction_cost_bps()
-        )
+            all_names = sorted(set(qual["sec_code"]) | set(current_positions["secCode"]))
+            prices = portfolio.fetch_prices(engine, run_date, all_names)
+            if bench not in prices:
+                prices.update(portfolio.fetch_prices(engine, run_date, [bench]))
 
-        new_positions, new_cash = portfolio.apply_trades(marked, trades, cash)
-        portfolio.persist_positions(engine, run_date, new_positions)
-        portfolio.persist_trades(engine, run_date, trades)
-        bench_nav = portfolio.benchmark_nav_for(
-            engine, sim_start_date, run_date, float(config.initial_capital()), bench
-        )
-        portfolio.persist_nav(engine, run_date, new_cash, new_positions, bench_nav)
+            marked = portfolio.mark_to_market(current_positions, prices)
+            nav_pre = cash + (
+                float(marked["market_value"].sum()) if not marked.empty else 0.0
+            )
 
-        result = {
-            "run_date": str(run_date),
-            "n_positions": int(len(new_positions)),
-            "n_trades": int(len(trades)),
-            "cash": round(new_cash, 2),
-            "nav": round(
-                new_cash
-                + (
-                    float(new_positions["market_value"].sum())
-                    if not new_positions.empty
-                    else 0.0
-                ),
-                2,
-            ),
-            "benchmark_nav": round(bench_nav, 2) if bench_nav else None,
-        }
-        logger.info("sim result: %s", result)
-        return result
+            target_names = select_target_names(
+                qual,
+                list(marked["secCode"]) if not marked.empty else [],
+                strategy.max_positions,
+                swap_rule=strategy.swap_rule,
+            )
+            target_shares = compute_target_shares(
+                target_names,
+                prices,
+                nav_pre,
+                strategy.max_positions,
+                weighting=strategy.weighting,
+                ratios=ratios,
+            )
+            current_shares = (
+                {row.secCode: int(row.shares) for row in marked.itertuples()}
+                if not marked.empty
+                else {}
+            )
+            trades = generate_trades(
+                current_shares, target_shares, prices, strategy.transaction_cost_bps
+            )
+            new_positions, new_cash = portfolio.apply_trades(marked, trades, cash)
+            portfolio.persist_positions(engine, run_date, new_positions, strategy.name)
+            portfolio.persist_trades(engine, run_date, trades, strategy.name)
+            bench_nav = portfolio.benchmark_nav_for(
+                engine, sim_start_date, run_date, float(strategy.initial_capital), bench
+            )
+            portfolio.persist_nav(
+                engine, run_date, new_cash, new_positions, bench_nav, strategy.name
+            )
 
-    rebalance()
+            pos_value = (
+                float(new_positions["market_value"].sum()) if not new_positions.empty else 0.0
+            )
+            results[strategy.name] = {
+                "n_positions": int(len(new_positions)),
+                "n_trades": len(trades),
+                "nav": round(new_cash + pos_value, 2),
+                "benchmark_nav": round(bench_nav, 2) if bench_nav else None,
+            }
+            logger.info("[%s] %s", strategy.name, results[strategy.name])
+
+        return {"run_date": str(run_date), "results": results}
+
+    rebalance_all()
 
 
-def _sim_start_date(engine):
-    """Earliest as_of_date in t_sim_portfolio_nav — the day the sim
-    started, used as the benchmark anchor."""
+def _sim_start_date(engine, strategy_name: str):
+    """Earliest as_of_date for this strategy — used as benchmark anchor."""
     from sqlalchemy import text
 
     with engine.connect() as conn:
         row = conn.execute(
-            text("SELECT MIN(as_of_date) FROM t_sim_portfolio_nav")
+            text(
+                "SELECT MIN(as_of_date) FROM t_sim_portfolio_nav WHERE strategy_name = :s"
+            ),
+            {"s": strategy_name},
         ).first()
     return row[0] if row else None
 

--- a/alembic/versions/0007_multi_strategy.py
+++ b/alembic/versions/0007_multi_strategy.py
@@ -1,0 +1,79 @@
+"""multi-strategy: scope sim tables by strategy_name
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-04-25
+
+Adds strategy_name to t_sim_positions, t_sim_trades, and
+t_sim_portfolio_nav so multiple strategies can share the same screen
+output but maintain independent portfolios.
+
+Existing rows are backfilled as 'netcash_top20_equal' (the baseline
+that the original sim DAG was running). Composite keys are rebuilt
+with strategy_name as the leading column.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+DEFAULT_STRATEGY = "netcash_top20_equal"
+
+
+def upgrade() -> None:
+    # 1) Add column nullable, backfill, then make NOT NULL.
+    for table in ("t_sim_positions", "t_sim_trades", "t_sim_portfolio_nav"):
+        op.add_column(table, sa.Column("strategy_name", sa.String(50)))
+        op.execute(
+            f"UPDATE {table} SET strategy_name = '{DEFAULT_STRATEGY}' WHERE strategy_name IS NULL"
+        )
+        op.alter_column(table, "strategy_name", existing_type=sa.String(50), nullable=False)
+
+    # 2) Rebuild constraints with strategy_name as leading column.
+    op.drop_constraint("t_sim_positions_pkey", "t_sim_positions", type_="primary")
+    op.create_primary_key(
+        "t_sim_positions_pkey",
+        "t_sim_positions",
+        ["strategy_name", "as_of_date", "secCode"],
+    )
+
+    op.drop_constraint("uq_t_sim_trades_natural", "t_sim_trades", type_="unique")
+    op.create_unique_constraint(
+        "uq_t_sim_trades_natural",
+        "t_sim_trades",
+        ["strategy_name", "trade_date", "secCode", "side", "shares", "price"],
+    )
+    # trade_id surrogate PK already exists, no change needed.
+
+    op.drop_constraint("t_sim_portfolio_nav_pkey", "t_sim_portfolio_nav", type_="primary")
+    op.create_primary_key(
+        "t_sim_portfolio_nav_pkey",
+        "t_sim_portfolio_nav",
+        ["strategy_name", "as_of_date"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("t_sim_portfolio_nav_pkey", "t_sim_portfolio_nav", type_="primary")
+    op.create_primary_key(
+        "t_sim_portfolio_nav_pkey", "t_sim_portfolio_nav", ["as_of_date"]
+    )
+
+    op.drop_constraint("uq_t_sim_trades_natural", "t_sim_trades", type_="unique")
+    op.create_unique_constraint(
+        "uq_t_sim_trades_natural",
+        "t_sim_trades",
+        ["trade_date", "secCode", "side", "shares", "price"],
+    )
+
+    op.drop_constraint("t_sim_positions_pkey", "t_sim_positions", type_="primary")
+    op.create_primary_key(
+        "t_sim_positions_pkey", "t_sim_positions", ["as_of_date", "secCode"]
+    )
+
+    for table in ("t_sim_positions", "t_sim_trades", "t_sim_portfolio_nav"):
+        op.drop_column(table, "strategy_name")

--- a/alembic/versions/0008_add_adj_close.py
+++ b/alembic/versions/0008_add_adj_close.py
@@ -1,0 +1,41 @@
+"""add split-adjusted close + adjustment factor to t_daily_stock_perf
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-04-25
+
+The original price ingest stored only the unadjusted close (`C` from
+JQuants v2). Backtests that span a stock split show fake price
+collapses on the split day — caught when 1306 (TOPIX ETF) split ~10:1
+between Dec 2025 and Mar 2026 and our benchmark NAV "dropped" 86%
+overnight.
+
+JQuants v2 daily_quotes already returns `AdjC` (split-adjusted close)
+and `AdjFactor` per row; we just need columns to put them in. Backfill
+is done by re-running `backfill_window.py --phase=prices`, which now
+populates these alongside the existing `close` and `marketCap`.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "t_daily_stock_perf",
+        sa.Column("adj_close", sa.Numeric(18, 4)),
+    )
+    op.add_column(
+        "t_daily_stock_perf",
+        sa.Column("adj_factor", sa.Numeric(18, 8)),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("t_daily_stock_perf", "adj_factor")
+    op.drop_column("t_daily_stock_perf", "adj_close")

--- a/alembic/versions/0009_add_operating_income.py
+++ b/alembic/versions/0009_add_operating_income.py
@@ -1,0 +1,37 @@
+"""add operating_income to financials annual mart
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-04-26
+
+Net-cash screen alone produces value traps — companies with structural
+net cash but stagnant or declining operations that the market correctly
+prices low (e.g. 双葉電子工業, コロナ in our 2022 cohort). Adding an
+operating-income filter lets the screen require "solid profitability"
+alongside net cash.
+
+Operating income is a CurrentYearDuration fact (income-statement flow,
+not balance-sheet snapshot). build_annual_mart.py is updated to query
+both Instant and Duration facts — the Duration filings have the same
+period_end as the Instant balance-sheet snapshot, so they collapse onto
+the same mart row.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "t_financials_annual",
+        sa.Column("operating_income", sa.Numeric(20, 4)),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("t_financials_annual", "operating_income")

--- a/alembic/versions/0010_add_net_sales.py
+++ b/alembic/versions/0010_add_net_sales.py
@@ -1,0 +1,34 @@
+"""add net_sales to financials annual mart
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-04-26
+
+Net sales (売上高) lets the screen distinguish real turnarounds (op
+income recovering on RISING revenue) from one-off cost cuts (op income
+recovering with FLAT revenue — usually fragile).
+
+Same data path as operating_income: it's a CurrentYearDuration fact
+that's already in t_financials. New mart column lets the screen
+self-join to compute year-over-year sales growth alongside op income
+growth.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "t_financials_annual",
+        sa.Column("net_sales", sa.Numeric(20, 4)),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("t_financials_annual", "net_sales")

--- a/docs/analysis_notes.md
+++ b/docs/analysis_notes.md
@@ -1,0 +1,90 @@
+# Empirical findings — net-cash screening on TSE
+
+A running log of what we've validated against the database. Decisions
+that landed in production code are summarized here so future readers
+(and future-us) can see the rationale.
+
+## 1. Formula: `total_liabilities` beats `interest_bearing_debt`
+
+The canonical Japanese ネットキャッシュ比率 textbook uses
+`current_assets − interest_bearing_debt + 0.7 × investment_securities`.
+Our quintile analysis on 285 small-caps (¥30B–¥60B mc, Aug 2025
+baseline → Apr 2026) plus a 1,800-stock 3-year study at
+<https://zenn.dev/morim34/articles/ff991f32187d96> both found that
+substituting `total_liabilities` for `interest_bearing_debt` gives a
+cleaner monotonic ratio→return relationship.
+
+| Formula | Q1 | Q2 | Q3 | Q4 | Q5 |
+|---|---|---|---|---|---|
+| `interest_bearing_debt` | +8% | +12% | +20% | +21% | **+9%** ← Q5 collapse |
+| `total_liabilities` | +7% | +11% | +17% | +22% | +22% |
+
+The interest-bearing form scores companies with no bank debt but huge
+trade payables (operating distress) artificially high. Total
+liabilities catches that. The mart still stores both;
+`screening/metrics.py` uses `total_liabilities`.
+
+## 2. Op-income yield filter cuts value traps
+
+Net-cash alone produces value traps — companies with structural cash
+but stagnant operations the market correctly prices low. A 2022-cohort
+test (19 stocks ¥15-50B mc with ratio > 1.5) showed:
+
+- 4 stocks held to the 3-year deadline; 3 of those underperformed
+  (双葉電子工業 +10%, コロナ +9%, 大平洋金属 +20%)
+- All 3 had op_yield < 5% at entry
+
+Adding `op_income / market_cap > 5%` to the screen catches 3 of 5
+worst traps from this cohort. Cost: drops 1 turnaround winner (67940
+フォスター電機 entered with an operating loss but returned +89%).
+Net mean improves from +63.4% (unfiltered) to +73.9% (kept group).
+
+Live screen on 2026-04-24: ratio≥1 universe shrinks 300 → 163 → 95
+after stacking ratio + op_yield + 6m_momentum filters.
+
+## 3. Turnaround signal — additive only, not a hard filter
+
+We extended the parser to keep `Prior1Year*` XBRL contexts and added
+`compute_turnaround_score(engine, run_date)` that returns YoY changes
+in op income, sales, and operating margin via a self-join on
+`t_financials_annual` (LAG window function).
+
+Tested on the 2022 cohort with the rule
+`op_income_yoy > 20% AND sales_yoy > 0`:
+
+- Catches 9 of 19 stocks; mean return **+63%** (same as baseline)
+- Misses 5 deep-trough winners with negative or undefined op_yoy at
+  entry: 87060 (broker, N/A sales concept), 67940 (loss-to-loss
+  transition, op_yoy = −∞), 18110, 51610, 88810
+- Includes 1 cyclical-peak trap: 55410 大平洋金属 with op_yoy +1,074%
+  on +77% sales — looked like a strong turnaround but was a
+  commodities cycle high
+
+**Conclusion**: turnaround is best used as an additive signal to
+surface candidates, not as a hard filter. The "quality (op_yield>5%
+AND mom>0%) AND turnaround (op_yoy>20% AND sales_yoy>0)" intersection
+on the 2022 cohort had n=4 stocks at +84.6% mean — promising but
+sample is too small to draw conclusions. Re-test in a year with more
+data.
+
+## 4. Look-ahead bias in the production screen — known caveat
+
+`screening/metrics.py::_SCREEN_SQL` filters `period_end <= run_date`,
+not `submitDateTime <= run_date`. Fine for live trading (filings are
+known once submitted), but produces optimistic backtests because the
+screen "sees" filings before their actual submission date. The
+backtest scripts (`backtest_smallcap_netcash.py`, `cross_table_…`)
+use `submitDateTime` for honest results.
+
+## 5. Known concept-coverage gaps
+
+Banks, brokers, and insurance companies use different XBRL concepts
+than industrials:
+- Brokers use `営業収益` (operating revenue), not `売上高` (net sales)
+- Insurance companies use `経常収益`
+- Banks use 業務粗利益 / 業務純益
+
+Our `concepts.py` covers industrials. Financial firms appear with
+`net_sales = NULL` and `sales_yoy` undefined. Adding these concept
+IDs is straightforward — deferred until we want to screen the
+financial sector specifically.

--- a/scripts/backfill_window.py
+++ b/scripts/backfill_window.py
@@ -170,7 +170,15 @@ def step_prices(engine, jq: JQuantsClient, d: date) -> int:
     quotes = jq.daily_quotes(target_date=d)
     if quotes.empty:
         return 0
-    quotes = quotes.rename(columns={"Code": "ShokenCode", "C": "close", "Vo": "volume"})
+    quotes = quotes.rename(
+        columns={
+            "Code": "ShokenCode",
+            "C": "close",
+            "Vo": "volume",
+            "AdjC": "adj_close",
+            "AdjFactor": "adj_factor",
+        }
+    )
     quotes["ShokenCode"] = quotes["ShokenCode"].astype(str)
     quotes = quotes.dropna(subset=["close"])
 
@@ -185,7 +193,11 @@ def step_prices(engine, jq: JQuantsClient, d: date) -> int:
         ).fetchall()
     shares = pd.DataFrame(rows, columns=["ShokenCode", "issued_shares"])
 
-    merged = quotes[["ShokenCode", "close", "volume"]].merge(shares, on="ShokenCode", how="left")
+    cols = ["ShokenCode", "close", "volume"]
+    for c in ("adj_close", "adj_factor"):
+        if c in quotes.columns:
+            cols.append(c)
+    merged = quotes[cols].merge(shares, on="ShokenCode", how="left")
     merged["Date"] = d
     merged["marketCap"] = (
         merged["close"].astype("float64") * merged["issued_shares"].astype("float64")
@@ -200,14 +212,25 @@ def step_prices(engine, jq: JQuantsClient, d: date) -> int:
                 "close": float(r["close"]) if pd.notna(r["close"]) else None,
                 "volume": int(r["volume"]) if pd.notna(r["volume"]) else None,
                 "marketCap": int(r["marketCap"]) if pd.notna(r["marketCap"]) else None,
+                "adj_close": float(r["adj_close"])
+                if "adj_close" in merged.columns and pd.notna(r["adj_close"])
+                else None,
+                "adj_factor": float(r["adj_factor"])
+                if "adj_factor" in merged.columns and pd.notna(r["adj_factor"])
+                else None,
             }
         )
     sql = text(
         """
-        INSERT INTO t_daily_stock_perf ("Date","ShokenCode",close,volume,"marketCap")
-        VALUES (:Date,:ShokenCode,:close,:volume,:marketCap)
+        INSERT INTO t_daily_stock_perf
+            ("Date","ShokenCode",close,volume,"marketCap",adj_close,adj_factor)
+        VALUES (:Date,:ShokenCode,:close,:volume,:marketCap,:adj_close,:adj_factor)
         ON CONFLICT ("Date","ShokenCode") DO UPDATE SET
-          close=EXCLUDED.close, volume=EXCLUDED.volume, "marketCap"=EXCLUDED."marketCap"
+          close=EXCLUDED.close,
+          volume=EXCLUDED.volume,
+          "marketCap"=EXCLUDED."marketCap",
+          adj_close=EXCLUDED.adj_close,
+          adj_factor=EXCLUDED.adj_factor
         """
     )
     with engine.begin() as conn:

--- a/scripts/backfill_window.py
+++ b/scripts/backfill_window.py
@@ -1,17 +1,30 @@
-"""Run the full daily pipeline (doclist → xbrl → prices → screen → sim)
-across a date window, in dependency order.
+"""Run the daily pipeline across a date window, optionally one phase
+at a time.
 
 Same business logic as the Airflow DAGs (re-uses everything in src/),
-just driven from a single process instead of via airflow scheduler.
-Idempotent — every step upserts or deletes-then-rewrites for its date,
-so a partial run can be re-launched safely.
+just driven from a single process. Idempotent — every step upserts or
+deletes-then-rewrites for its date, so a partial run can be re-launched.
 
 Usage:
+    # Full pipeline (doclist → xbrl → prices → screen → sim)
     python scripts/backfill_window.py 2026-04-15 2026-04-22
+
+    # Single phase only — useful for the 12-month bootstrap where
+    # prices and financials want different runtime characteristics.
+    python scripts/backfill_window.py 2025-04-25 2026-04-24 --phase=prices
+    python scripts/backfill_window.py 2025-04-25 2026-04-24 --phase=financials
+    python scripts/backfill_window.py 2025-04-25 2026-04-24 --phase=marketcap
+
+Phases:
+    prices        per date: step_prices only. Skips weekends.
+    financials    per date: step_doclist + step_xbrl_ingest.
+    marketcap     once: UPDATE marketCap from latest known issued_shares.
+    all (default) per date: everything (current behavior).
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 import tempfile
 from datetime import date, datetime, timedelta
@@ -280,50 +293,102 @@ def step_sim(engine, d: date) -> dict[str, dict]:
     return {s.name: step_sim_one(engine, d, s, qual) for s in STRATEGIES}
 
 
-def main():
-    if len(sys.argv) != 3:
-        print("usage: backfill_window.py START END", file=sys.stderr)
-        sys.exit(1)
-    start = datetime.strptime(sys.argv[1], "%Y-%m-%d").date()
-    end = datetime.strptime(sys.argv[2], "%Y-%m-%d").date()
+def step_recompute_marketcap(engine) -> int:
+    """Fill in NULL marketCap on t_daily_stock_perf using the most recent
+    known issued_shares per company. Single SQL UPDATE; safe to re-run.
 
+    Use after a prices-only backfill once t_financials_annual has been
+    populated by a financials backfill — historical price rows that
+    were inserted before any annual report had been ingested for the
+    company will have marketCap=NULL and need this fix-up pass.
+    """
+    sql = text(
+        """
+        UPDATE t_daily_stock_perf p
+        SET "marketCap" = (p.close * fa.issued_shares)::bigint
+        FROM (
+            SELECT DISTINCT ON ("secCode") "secCode", issued_shares
+            FROM t_financials_annual
+            WHERE issued_shares IS NOT NULL
+            ORDER BY "secCode", period_end DESC
+        ) fa
+        WHERE p."ShokenCode" = fa."secCode"
+          AND p."marketCap" IS NULL
+          AND p.close IS NOT NULL
+        """
+    )
+    with engine.begin() as conn:
+        result = conn.execute(sql)
+    return result.rowcount or 0
+
+
+def _run_phase_per_date(phase: str, start: date, end: date) -> None:
     engine = db.get_engine()
-    edinet_key = config.edinet_key()
-    jq = JQuantsClient(config.jquants_api_key())
+    edinet_key = config.edinet_key() if phase in ("financials", "all") else None
+    jq = JQuantsClient(config.jquants_api_key()) if phase in ("prices", "all") else None
 
     for d in daterange(start, end):
         print(f"\n=== {d} ({d.strftime('%a')}) ===")
-        try:
-            n_doc = step_doclist(engine, edinet_key, d)
-            print(f"  doclist:  {n_doc} filings")
-            n_filings, n_facts, n_mart = step_xbrl_ingest(engine, edinet_key, d)
-            print(f"  xbrl:     {n_filings} parsed, {n_facts} facts, {n_mart} mart rows")
-        except Exception as e:
-            print(f"  [error] EDINET step failed: {type(e).__name__}: {e}")
-            continue
 
-        # Skip price/screen/sim on weekends — JQuants returns nothing.
+        if phase in ("financials", "all"):
+            try:
+                n_doc = step_doclist(engine, edinet_key, d)
+                print(f"  doclist:  {n_doc} filings")
+                n_filings, n_facts, n_mart = step_xbrl_ingest(engine, edinet_key, d)
+                print(f"  xbrl:     {n_filings} parsed, {n_facts} facts, {n_mart} mart rows")
+            except Exception as e:
+                print(f"  [error] EDINET step failed: {type(e).__name__}: {e}")
+                if phase == "all":
+                    continue
+
         if d.weekday() >= 5:
-            print("  (weekend — skipping prices/screen/sim)")
+            if phase in ("prices", "all"):
+                print("  (weekend — skipping prices/screen/sim)")
             continue
 
-        try:
-            n_q = step_prices(engine, jq, d)
-            print(f"  prices:   {n_q} quotes")
-            if n_q == 0:
-                print("  (no prices — skipping screen/sim)")
-                continue
-            n_scored, n_qual = step_screen(engine, d)
-            print(f"  screen:   {n_scored} scored, {n_qual} qualify")
-            results = step_sim(engine, d)
-            for name, r in results.items():
-                print(
-                    f"  sim[{name:<32}]: {r['n_positions']:>2} pos, "
-                    f"{r['n_trades']:>2} tx, NAV={r['nav']:>15,.0f}"
-                )
-        except Exception as e:
-            print(f"  [error] prices/screen/sim failed: {type(e).__name__}: {e}")
+        if phase in ("prices", "all"):
+            try:
+                n_q = step_prices(engine, jq, d)
+                print(f"  prices:   {n_q} quotes")
+                if phase == "prices":
+                    continue
+                if n_q == 0:
+                    print("  (no prices — skipping screen/sim)")
+                    continue
+                n_scored, n_qual = step_screen(engine, d)
+                print(f"  screen:   {n_scored} scored, {n_qual} qualify")
+                results = step_sim(engine, d)
+                for name, r in results.items():
+                    print(
+                        f"  sim[{name:<32}]: {r['n_positions']:>2} pos, "
+                        f"{r['n_trades']:>2} tx, NAV={r['nav']:>15,.0f}"
+                    )
+            except Exception as e:
+                print(f"  [error] prices/screen/sim failed: {type(e).__name__}: {e}")
 
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("start", help="window start date (YYYY-MM-DD)")
+    parser.add_argument("end", help="window end date (YYYY-MM-DD, inclusive)")
+    parser.add_argument(
+        "--phase",
+        choices=("prices", "financials", "marketcap", "all"),
+        default="all",
+        help="which step(s) to run; default 'all' = full pipeline per date",
+    )
+    args = parser.parse_args()
+
+    start = datetime.strptime(args.start, "%Y-%m-%d").date()
+    end = datetime.strptime(args.end, "%Y-%m-%d").date()
+
+    if args.phase == "marketcap":
+        engine = db.get_engine()
+        n = step_recompute_marketcap(engine)
+        print(f"marketcap recompute: updated {n} rows in t_daily_stock_perf")
+        return
+
+    _run_phase_per_date(args.phase, start, end)
     print("\nbackfill complete.")
 
 

--- a/scripts/backfill_window.py
+++ b/scripts/backfill_window.py
@@ -38,6 +38,7 @@ from stock_screening.simulation.rebalance import (
     generate_trades,
     select_target_names,
 )
+from stock_screening.simulation.strategies import STRATEGIES, Strategy
 
 
 def daterange(start: date, end: date):
@@ -208,23 +209,15 @@ def step_screen(engine, d: date) -> tuple[int, int]:
     return len(df), n_qual
 
 
-def step_sim(engine, d: date) -> dict:
-    portfolio.delete_outputs_for_date(engine, d)
-    prev = portfolio.load_previous_snapshot(engine, d)
-
-    with engine.connect() as conn:
-        qrows = conn.execute(
-            text(
-                'SELECT "secCode" AS sec_code, ratio FROM t_screen_results '
-                "WHERE run_date=:d AND qualifies=TRUE ORDER BY ratio DESC"
-            ),
-            {"d": d},
-        ).fetchall()
-    qual = pd.DataFrame(qrows, columns=["sec_code", "ratio"])
+def step_sim_one(engine, d: date, strategy: Strategy, qual: pd.DataFrame) -> dict:
+    portfolio.delete_outputs_for_date(engine, d, strategy.name)
+    prev = portfolio.load_previous_snapshot(engine, d, strategy.name)
 
     if prev is None:
-        cash = float(config.initial_capital())
-        positions = pd.DataFrame(columns=["secCode", "shares", "avg_cost", "last_price", "market_value"])
+        cash = float(strategy.initial_capital)
+        positions = pd.DataFrame(
+            columns=["secCode", "shares", "avg_cost", "last_price", "market_value"]
+        )
     else:
         cash = prev.cash
         positions = prev.positions
@@ -235,19 +228,32 @@ def step_sim(engine, d: date) -> dict:
     nav_pre = cash + (float(marked["market_value"].sum()) if not marked.empty else 0.0)
 
     target_names = select_target_names(
-        qual, list(marked["secCode"]) if not marked.empty else [], config.max_positions()
+        qual,
+        list(marked["secCode"]) if not marked.empty else [],
+        strategy.max_positions,
+        swap_rule=strategy.swap_rule,
     )
-    target_shares = compute_target_shares(target_names, prices, nav_pre, config.max_positions())
+    ratios = dict(zip(qual["sec_code"], qual["ratio"], strict=True)) if not qual.empty else {}
+    target_shares = compute_target_shares(
+        target_names,
+        prices,
+        nav_pre,
+        strategy.max_positions,
+        weighting=strategy.weighting,
+        ratios=ratios,
+    )
     current_shares = (
         {row.secCode: int(row.shares) for row in marked.itertuples()}
         if not marked.empty
         else {}
     )
-    trades = generate_trades(current_shares, target_shares, prices, config.transaction_cost_bps())
+    trades = generate_trades(
+        current_shares, target_shares, prices, strategy.transaction_cost_bps
+    )
     new_positions, new_cash = portfolio.apply_trades(marked, trades, cash)
-    portfolio.persist_positions(engine, d, new_positions)
-    portfolio.persist_trades(engine, d, trades)
-    portfolio.persist_nav(engine, d, new_cash, new_positions, None)
+    portfolio.persist_positions(engine, d, new_positions, strategy.name)
+    portfolio.persist_trades(engine, d, trades, strategy.name)
+    portfolio.persist_nav(engine, d, new_cash, new_positions, None, strategy.name)
 
     pos_value = float(new_positions["market_value"].sum()) if not new_positions.empty else 0.0
     return {
@@ -255,6 +261,23 @@ def step_sim(engine, d: date) -> dict:
         "n_trades": len(trades),
         "nav": new_cash + pos_value,
     }
+
+
+def step_sim(engine, d: date) -> dict[str, dict]:
+    """Run every registered strategy for date `d`. They all read the
+    same screen output but maintain independent portfolios."""
+    with engine.connect() as conn:
+        qrows = conn.execute(
+            text(
+                'SELECT "secCode" AS sec_code, ratio FROM t_screen_results '
+                "WHERE run_date=:d AND qualifies=TRUE ORDER BY ratio DESC"
+            ),
+            {"d": d},
+        ).fetchall()
+    qual = pd.DataFrame(qrows, columns=["sec_code", "ratio"])
+    qual["ratio"] = qual["ratio"].astype(float)
+
+    return {s.name: step_sim_one(engine, d, s, qual) for s in STRATEGIES}
 
 
 def main():
@@ -292,11 +315,12 @@ def main():
                 continue
             n_scored, n_qual = step_screen(engine, d)
             print(f"  screen:   {n_scored} scored, {n_qual} qualify")
-            sim = step_sim(engine, d)
-            print(
-                f"  sim:      {sim['n_positions']} positions, {sim['n_trades']} trades, "
-                f"NAV={sim['nav']:,.0f}"
-            )
+            results = step_sim(engine, d)
+            for name, r in results.items():
+                print(
+                    f"  sim[{name:<32}]: {r['n_positions']:>2} pos, "
+                    f"{r['n_trades']:>2} tx, NAV={r['nav']:>15,.0f}"
+                )
         except Exception as e:
             print(f"  [error] prices/screen/sim failed: {type(e).__name__}: {e}")
 

--- a/scripts/backtest_smallcap_netcash.py
+++ b/scripts/backtest_smallcap_netcash.py
@@ -1,0 +1,280 @@
+"""One-off backtest: net-cash-ratio screen filtered to mid-/small-cap
+companies (¥30B–¥60B ≈ $200M–$400M), $100k initial capital, equal-
+weight top-N daily rebalance with strict-improvement swap rule.
+
+Differs from the production sim in two ways:
+
+1. Adds a marketCap filter on top of the screen — only names in the
+   target range are eligible.
+2. Filters mart rows by `t_doc_list.submitDateTime <= run_date`, not
+   the production screen's `period_end <= run_date`. This is the
+   look-ahead fix the plan documented as a follow-up — necessary for
+   any honest backtest. (The production screen still uses period_end,
+   which is fine for live trading where filings are known once
+   submitted; it just produces optimistic backtests.)
+
+Bypasses the STRATEGIES registry and writes nothing to the sim
+tables — output is to stdout only. Run it as exploratory analysis,
+then promote to a registered strategy if it looks promising.
+
+Usage: scripts/backtest_smallcap_netcash.py 2025-04-25 2026-04-24
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+from stock_screening.simulation import portfolio
+from stock_screening.simulation.rebalance import (
+    compute_target_shares,
+    generate_trades,
+    select_target_names,
+)
+
+# --- backtest parameters -------------------------------------------------
+
+INITIAL_CAPITAL = 15_000_000      # ¥15M ≈ $100k @ 150 JPY/USD
+MIN_MARKET_CAP = 30_000_000_000   # ¥30B ≈ $200M
+MAX_MARKET_CAP = 60_000_000_000   # ¥60B ≈ $400M
+MIN_VOLUME = 1_000                # daily volume floor; skips dead tickers
+MAX_POSITIONS = 10                # narrower than 20 since the cap band is tight
+TRANSACTION_COST_BPS = 10
+BENCHMARK_TICKER = "13060"   # 1306 + JPX check digit, as stored by JQuants v2
+QUALIFY_THRESHOLD = 1.0
+INVESTMENT_SECURITIES_HAIRCUT = 0.7
+
+# --- screen with market-cap filter and look-ahead fix --------------------
+
+_SCREEN_SQL = text(
+    """
+    WITH visible AS (
+        SELECT fa."secCode" AS sec_code,
+               fa.period_end,
+               fa.current_assets,
+               fa.interest_bearing_debt,
+               fa.investment_securities
+        FROM t_financials_annual fa
+        JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+        WHERE dl."submitDateTime"::date <= :run_date
+    ),
+    latest AS (
+        SELECT DISTINCT ON (sec_code) sec_code, period_end,
+               current_assets, interest_bearing_debt, investment_securities
+        FROM visible
+        ORDER BY sec_code, period_end DESC
+    )
+    SELECT l.sec_code,
+           l.current_assets, l.interest_bearing_debt, l.investment_securities,
+           d."marketCap" AS market_cap,
+           d.adj_close,
+           d.volume
+    FROM latest l
+    JOIN t_daily_stock_perf d
+      ON d."ShokenCode" = l.sec_code
+     AND d."Date" = :run_date
+    WHERE d."marketCap" BETWEEN :min_mc AND :max_mc
+      AND COALESCE(d.volume, 0) >= :min_vol
+      AND d.adj_close IS NOT NULL
+    """
+)
+
+
+def screen(engine, run_date: date) -> pd.DataFrame:
+    with engine.connect() as conn:
+        rows = conn.execute(
+            _SCREEN_SQL,
+            {
+                "run_date": run_date,
+                "min_mc": MIN_MARKET_CAP,
+                "max_mc": MAX_MARKET_CAP,
+                "min_vol": MIN_VOLUME,
+            },
+        ).fetchall()
+    cols = [
+        "sec_code", "current_assets", "interest_bearing_debt",
+        "investment_securities", "market_cap", "adj_close", "volume",
+    ]
+    df = pd.DataFrame(rows, columns=cols)
+    if df.empty:
+        return df.assign(ratio=pd.Series(dtype=float), qualifies=pd.Series(dtype=bool))
+    for c in ("current_assets", "interest_bearing_debt", "investment_securities", "market_cap", "adj_close"):
+        df[c] = df[c].astype(float)
+    df["ratio"] = (
+        df["current_assets"].fillna(0)
+        - df["interest_bearing_debt"].fillna(0)
+        + INVESTMENT_SECURITIES_HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["market_cap"]
+    df["qualifies"] = df["ratio"] >= QUALIFY_THRESHOLD
+    return df
+
+
+# --- benchmark -----------------------------------------------------------
+
+def fetch_benchmark_series(engine, ticker: str, start: date, end: date) -> dict[date, float]:
+    """Use adj_close — handles splits / consolidations correctly."""
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                'SELECT "Date", adj_close FROM t_daily_stock_perf '
+                'WHERE "ShokenCode" = :c AND "Date" BETWEEN :s AND :e AND adj_close IS NOT NULL '
+                'ORDER BY "Date"'
+            ),
+            {"c": ticker, "s": start, "e": end},
+        ).fetchall()
+    return {r[0]: float(r[1]) for r in rows}
+
+
+def fetch_adj_prices(engine, run_date: date, sec_codes: list[str]) -> dict[str, float]:
+    """Adj-close lookup for any names — strategy MTM and trade execution."""
+    if not sec_codes:
+        return {}
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                'SELECT "ShokenCode", adj_close FROM t_daily_stock_perf '
+                'WHERE "Date" = :d AND "ShokenCode" = ANY(:codes) AND adj_close IS NOT NULL'
+            ),
+            {"d": run_date, "codes": sec_codes},
+        ).fetchall()
+    return {r[0]: float(r[1]) for r in rows}
+
+
+# --- backtest loop -------------------------------------------------------
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: backtest_smallcap_netcash.py START END", file=sys.stderr)
+        sys.exit(1)
+
+    start = datetime.strptime(sys.argv[1], "%Y-%m-%d").date()
+    end = datetime.strptime(sys.argv[2], "%Y-%m-%d").date()
+    engine = db.get_engine()
+
+    bench_prices = fetch_benchmark_series(engine, BENCHMARK_TICKER, start, end)
+    print(f"benchmark ({BENCHMARK_TICKER}) trading days: {len(bench_prices)}")
+
+    # In-memory portfolio state.
+    cash = float(INITIAL_CAPITAL)
+    positions = pd.DataFrame(
+        columns=["secCode", "shares", "avg_cost", "last_price", "market_value"]
+    )
+    sim_start_date: date | None = None
+    nav_history: list[tuple[date, float, float | None, int, int]] = []
+    all_trades = 0
+    total_commission = 0.0
+
+    d = start
+    while d <= end:
+        # Skip weekends — JQuants returns no quotes
+        if d.weekday() >= 5 or d not in bench_prices:
+            d += timedelta(days=1)
+            continue
+
+        df = screen(engine, d)
+        qual = df[df["qualifies"]].sort_values("ratio", ascending=False).reset_index(drop=True)
+
+        # Bootstrap on first trading day with any qualifying name.
+        if sim_start_date is None:
+            if qual.empty:
+                d += timedelta(days=1)
+                continue
+            sim_start_date = d
+
+        # Pull split-adjusted prices for held + qualifying names.
+        names = sorted(set(qual["sec_code"]) | set(positions["secCode"]))
+        prices = fetch_adj_prices(engine, d, names) if names else {}
+
+        marked = portfolio.mark_to_market(positions, prices) if not positions.empty else positions
+        nav_pre = cash + (float(marked["market_value"].sum()) if not marked.empty else 0.0)
+
+        target_names = select_target_names(
+            qual,
+            list(marked["secCode"]) if not marked.empty else [],
+            MAX_POSITIONS,
+            swap_rule="strict_improvement",
+        )
+        target_shares = compute_target_shares(
+            target_names, prices, nav_pre, MAX_POSITIONS, weighting="equal"
+        )
+        current_shares = (
+            {row.secCode: int(row.shares) for row in marked.itertuples()}
+            if not marked.empty
+            else {}
+        )
+        trades = generate_trades(current_shares, target_shares, prices, TRANSACTION_COST_BPS)
+        positions, cash = portfolio.apply_trades(marked, trades, cash)
+
+        all_trades += len(trades)
+        total_commission += sum(t.commission for t in trades)
+
+        nav = cash + (float(positions["market_value"].sum()) if not positions.empty else 0.0)
+        bench_nav = INITIAL_CAPITAL * (
+            bench_prices[d] / bench_prices[sim_start_date]
+        )
+        nav_history.append((d, nav, bench_nav, len(positions), len(qual)))
+
+        d += timedelta(days=1)
+
+    # --- report ----------------------------------------------------------
+
+    if not nav_history:
+        print("no qualifying names in window — nothing simulated")
+        return
+
+    print(f"\nSim period: {sim_start_date} → {nav_history[-1][0]}  "
+          f"({len(nav_history)} trading days)")
+    print(f"Initial capital: ¥{INITIAL_CAPITAL:,}")
+
+    df = pd.DataFrame(nav_history, columns=["date", "nav", "bench_nav", "n_pos", "n_qual"])
+    final_nav = df["nav"].iloc[-1]
+    final_bench = df["bench_nav"].iloc[-1]
+    sim_ret = (final_nav / INITIAL_CAPITAL - 1) * 100
+    bench_ret = (final_bench / INITIAL_CAPITAL - 1) * 100
+
+    # Max drawdown
+    running_max = df["nav"].cummax()
+    dd = (df["nav"] / running_max - 1) * 100
+    max_dd = dd.min()
+
+    bench_max = df["bench_nav"].cummax()
+    bench_dd = (df["bench_nav"] / bench_max - 1) * 100
+    bench_max_dd = bench_dd.min()
+
+    print(f"\nFinal NAV:        ¥{final_nav:>15,.0f}    ({sim_ret:+.2f}%)")
+    print(f"Benchmark NAV:    ¥{final_bench:>15,.0f}    ({bench_ret:+.2f}%)")
+    print(f"Excess return:                            {sim_ret - bench_ret:+.2f}%")
+    print(f"Max drawdown:     sim {max_dd:.2f}%  vs  benchmark {bench_max_dd:.2f}%")
+    print(f"Trades:           {all_trades}")
+    print(f"Total commission: ¥{total_commission:,.0f}  ({total_commission/INITIAL_CAPITAL*100:.2f}% of initial)")
+    print(f"Avg positions:    {df['n_pos'].mean():.1f}")
+    print(f"Avg eligible:     {df['n_qual'].mean():.1f}  (passing screen + cap filter)")
+
+    print("\nMonthly NAV (last day of month):")
+    df["ym"] = df["date"].apply(lambda x: x.strftime("%Y-%m"))
+    monthly = df.groupby("ym").last().reset_index()
+    for _, r in monthly.iterrows():
+        sim_pct = (r["nav"] / INITIAL_CAPITAL - 1) * 100
+        bench_pct = (r["bench_nav"] / INITIAL_CAPITAL - 1) * 100
+        print(f"  {r['ym']}  sim ¥{r['nav']:>15,.0f} ({sim_pct:+6.2f}%)   "
+              f"bench ¥{r['bench_nav']:>15,.0f} ({bench_pct:+6.2f}%)   "
+              f"n_pos={int(r['n_pos'])}, n_eligible={int(r['n_qual'])}")
+
+    print(f"\nFinal positions on {nav_history[-1][0]}:")
+    if positions.empty:
+        print("  (none)")
+    else:
+        for _, p in positions.sort_values("market_value", ascending=False).iterrows():
+            print(f"  {p['secCode']}: {int(p['shares']):>6} sh @ ¥{float(p['last_price']):>9,.0f}  "
+                  f"= ¥{float(p['market_value']):>15,.0f}  (avg cost ¥{float(p['avg_cost']):>8,.0f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backtest_smallcap_netcash.py
+++ b/scripts/backtest_smallcap_netcash.py
@@ -59,7 +59,7 @@ _SCREEN_SQL = text(
         SELECT fa."secCode" AS sec_code,
                fa.period_end,
                fa.current_assets,
-               fa.interest_bearing_debt,
+               fa.total_liabilities,
                fa.investment_securities
         FROM t_financials_annual fa
         JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
@@ -67,12 +67,12 @@ _SCREEN_SQL = text(
     ),
     latest AS (
         SELECT DISTINCT ON (sec_code) sec_code, period_end,
-               current_assets, interest_bearing_debt, investment_securities
+               current_assets, total_liabilities, investment_securities
         FROM visible
         ORDER BY sec_code, period_end DESC
     )
     SELECT l.sec_code,
-           l.current_assets, l.interest_bearing_debt, l.investment_securities,
+           l.current_assets, l.total_liabilities, l.investment_securities,
            d."marketCap" AS market_cap,
            d.adj_close,
            d.volume
@@ -99,17 +99,17 @@ def screen(engine, run_date: date) -> pd.DataFrame:
             },
         ).fetchall()
     cols = [
-        "sec_code", "current_assets", "interest_bearing_debt",
+        "sec_code", "current_assets", "total_liabilities",
         "investment_securities", "market_cap", "adj_close", "volume",
     ]
     df = pd.DataFrame(rows, columns=cols)
     if df.empty:
         return df.assign(ratio=pd.Series(dtype=float), qualifies=pd.Series(dtype=bool))
-    for c in ("current_assets", "interest_bearing_debt", "investment_securities", "market_cap", "adj_close"):
+    for c in ("current_assets", "total_liabilities", "investment_securities", "market_cap", "adj_close"):
         df[c] = df[c].astype(float)
     df["ratio"] = (
         df["current_assets"].fillna(0)
-        - df["interest_bearing_debt"].fillna(0)
+        - df["total_liabilities"].fillna(0)
         + INVESTMENT_SECURITIES_HAIRCUT * df["investment_securities"].fillna(0)
     ) / df["market_cap"]
     df["qualifies"] = df["ratio"] >= QUALIFY_THRESHOLD

--- a/scripts/cross_table_netcash_2022.py
+++ b/scripts/cross_table_netcash_2022.py
@@ -1,0 +1,322 @@
+"""3-year per-stock holding study, entered at end of 2022.
+
+Each stock with a high net-cash ratio at entry is "bought" at its
+2022-12-30 close and "sold" when EITHER:
+  (a) the daily-recomputed net-cash ratio falls below 1.0, OR
+  (b) the 3-year holding window ends (2025-12-30).
+
+The ratio re-evaluates daily because:
+  - market_cap shifts every trading day → denominator changes
+  - new annual reports may arrive during the holding window →
+    numerator changes (we use the latest filing visible as-of
+    each day, with submitDateTime <= that day)
+
+Output: a cross-table by (initial_net_cash_ratio bucket × initial
+market_cap bucket) showing count, mean return, median return.
+
+This is NOT a portfolio simulation — no initial capital, no shares,
+no commissions, no equal-weight. We compute one price-return number
+per stock and aggregate.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+
+ENTRY_DATE = date(2022, 12, 30)
+EXIT_DEADLINE = date(2025, 12, 30)  # 3 years from entry
+
+MIN_MARKET_CAP = 15_000_000_000   # ¥15B
+ENTRY_THRESHOLD = 1.5              # tighter qualifying bar (was 1.0)
+EXIT_THRESHOLD = 1.0               # still hold until full re-rating
+INVESTMENT_SECURITIES_HAIRCUT = 0.7
+
+# Finer ratio buckets within the new universe.
+RATIO_BUCKETS = [
+    ("1.5–1.75",  1.5,  1.75),
+    ("1.75–2.0",  1.75, 2.0),
+    ("2.0–2.5",   2.0,  2.5),
+    ("2.5–3.0",   2.5,  3.0),
+    ("3.0+",      3.0,  float("inf")),
+]
+
+# Market cap buckets in JPY
+MC_BUCKETS = [
+    ("¥15-30B",   15e9,  30e9),
+    ("¥30-100B",  30e9,  100e9),
+    ("¥100-500B", 100e9, 500e9),
+    ("¥500B+",    500e9, float("inf")),
+]
+
+
+def bucket(value: float, buckets: list[tuple[str, float, float]]) -> str:
+    for label, lo, hi in buckets:
+        if lo <= value < hi:
+            return label
+    return "out-of-range"
+
+
+def main():
+    engine = db.get_engine()
+
+    # Step 1: identify the universe at ENTRY_DATE.
+    # Latest mart row per company that was visible (filed) by ENTRY_DATE,
+    # joined to that day's price + market cap.
+    print(f"Building entry universe as of {ENTRY_DATE}...")
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode", fa.period_end,
+                           fa.current_assets, fa.total_liabilities, fa.investment_securities,
+                           fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                      AND fa.total_liabilities IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON ("secCode") *
+                    FROM visible ORDER BY "secCode", period_end DESC
+                )
+                SELECT l."secCode", l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.period_end,
+                       d.adj_close AS entry_price,
+                       d."marketCap" AS entry_mc
+                FROM latest l
+                JOIN t_daily_stock_perf d
+                  ON d."ShokenCode" = l."secCode" AND d."Date" = :entry
+                WHERE d.adj_close IS NOT NULL
+                  AND d."marketCap" IS NOT NULL
+                  AND d."marketCap" >= :min_mc
+                """
+            ),
+            {"entry": ENTRY_DATE, "min_mc": MIN_MARKET_CAP},
+        ).fetchall()
+
+    universe = pd.DataFrame(
+        rows,
+        columns=[
+            "sec_code", "current_assets", "total_liabilities", "investment_securities",
+            "period_end", "entry_price", "entry_mc",
+        ],
+    )
+    for c in ("current_assets", "total_liabilities", "investment_securities", "entry_price", "entry_mc"):
+        universe[c] = universe[c].astype(float)
+
+    universe["net_cash_numerator"] = (
+        universe["current_assets"]
+        - universe["total_liabilities"]
+        + INVESTMENT_SECURITIES_HAIRCUT * universe["investment_securities"].fillna(0)
+    )
+    universe["entry_ratio"] = universe["net_cash_numerator"] / universe["entry_mc"]
+
+    # Filter to "high net-cash" at entry
+    qualifying = universe[universe["entry_ratio"] >= ENTRY_THRESHOLD].reset_index(drop=True)
+    print(f"  {len(universe)} stocks ≥ ¥15B mc with mart data at entry")
+    print(f"  {len(qualifying)} of those have entry net-cash ratio ≥ {ENTRY_THRESHOLD}")
+
+    # Step 2: for each qualifying stock, walk daily prices and find exit.
+    # Exit = first day ratio < 1.0 (using latest visible mart numerator
+    # divided by that day's market cap), else EXIT_DEADLINE.
+    print(f"\nWalking forward to {EXIT_DEADLINE} for each stock...")
+
+    sec_codes = qualifying["sec_code"].tolist()
+
+    # Pre-fetch all the daily data for these stocks in the holding window.
+    with engine.connect() as conn:
+        price_rows = conn.execute(
+            text(
+                'SELECT "ShokenCode" AS sec_code, "Date", adj_close, "marketCap" '
+                "FROM t_daily_stock_perf "
+                'WHERE "ShokenCode" = ANY(:codes) '
+                'AND "Date" BETWEEN :start AND :end '
+                "AND adj_close IS NOT NULL AND \"marketCap\" IS NOT NULL "
+                'ORDER BY "ShokenCode", "Date"'
+            ),
+            {"codes": sec_codes, "start": ENTRY_DATE, "end": EXIT_DEADLINE},
+        ).fetchall()
+    prices = pd.DataFrame(price_rows, columns=["sec_code", "date", "adj_close", "market_cap"])
+    prices["adj_close"] = prices["adj_close"].astype(float)
+    prices["market_cap"] = prices["market_cap"].astype(float)
+
+    # Pre-fetch all visible mart rows that could become "latest" during the
+    # holding window — i.e. filings submitted between ENTRY_DATE and
+    # EXIT_DEADLINE (older ones are already in the entry universe).
+    with engine.connect() as conn:
+        mart_rows = conn.execute(
+            text(
+                """
+                SELECT fa."secCode" AS sec_code,
+                       dl."submitDateTime"::date AS submit_date,
+                       fa.current_assets, fa.total_liabilities, fa.investment_securities,
+                       fa.period_end
+                FROM t_financials_annual fa
+                JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                WHERE fa."secCode" = ANY(:codes)
+                  AND dl."submitDateTime"::date BETWEEN :start AND :end
+                  AND fa.current_assets IS NOT NULL
+                  AND fa.total_liabilities IS NOT NULL
+                ORDER BY fa."secCode", dl."submitDateTime"
+                """
+            ),
+            {"codes": sec_codes, "start": ENTRY_DATE, "end": EXIT_DEADLINE},
+        ).fetchall()
+    new_filings = pd.DataFrame(
+        mart_rows,
+        columns=["sec_code", "submit_date", "current_assets", "total_liabilities",
+                 "investment_securities", "period_end"],
+    )
+    for c in ("current_assets", "total_liabilities", "investment_securities"):
+        new_filings[c] = new_filings[c].astype(float)
+
+    # Compute per-stock exit
+    results = []
+    initial_state = qualifying.set_index("sec_code")[
+        ["entry_price", "entry_mc", "entry_ratio", "current_assets",
+         "total_liabilities", "investment_securities", "net_cash_numerator"]
+    ]
+
+    new_filings_by_stock = {
+        code: g.sort_values("submit_date") for code, g in new_filings.groupby("sec_code")
+    }
+    prices_by_stock = {code: g.sort_values("date") for code, g in prices.groupby("sec_code")}
+
+    for sec_code, init in initial_state.iterrows():
+        stock_prices = prices_by_stock.get(sec_code)
+        if stock_prices is None or stock_prices.empty:
+            continue
+
+        numerator = init["net_cash_numerator"]
+        stock_filings = new_filings_by_stock.get(sec_code, pd.DataFrame())
+
+        exit_date = None
+        exit_price = None
+        exit_reason = "deadline"
+
+        for _, row in stock_prices.iterrows():
+            d = row["date"]
+            mc = row["market_cap"]
+            adj = row["adj_close"]
+
+            # Refresh numerator if a new filing has landed by this date
+            if not stock_filings.empty:
+                applicable = stock_filings[stock_filings["submit_date"] <= d]
+                if not applicable.empty:
+                    latest = applicable.iloc[-1]
+                    numerator = (
+                        latest["current_assets"]
+                        - latest["total_liabilities"]
+                        + INVESTMENT_SECURITIES_HAIRCUT * (latest["investment_securities"] or 0)
+                    )
+
+            ratio = numerator / mc if mc > 0 else 0
+            if d >= ENTRY_DATE and ratio < EXIT_THRESHOLD:
+                exit_date = d
+                exit_price = adj
+                exit_reason = "ratio_below_exit"
+                break
+
+        if exit_date is None:
+            last = stock_prices.iloc[-1]
+            exit_date = last["date"]
+            exit_price = last["adj_close"]
+
+        period_return = (exit_price / init["entry_price"] - 1) * 100
+        days_held = (exit_date - ENTRY_DATE).days
+        results.append({
+            "sec_code": sec_code,
+            "entry_ratio": init["entry_ratio"],
+            "entry_mc": init["entry_mc"],
+            "entry_price": init["entry_price"],
+            "exit_date": exit_date,
+            "exit_price": exit_price,
+            "exit_reason": exit_reason,
+            "days_held": days_held,
+            "return_pct": period_return,
+        })
+
+    df = pd.DataFrame(results)
+    print(f"  {len(df)} stocks tracked")
+    print(f"  exit reasons: {df['exit_reason'].value_counts().to_dict()}")
+
+    # Step 3: bucket and cross-table
+    df["ratio_bucket"] = df["entry_ratio"].apply(lambda r: bucket(r, RATIO_BUCKETS))
+    df["mc_bucket"] = df["entry_mc"].apply(lambda m: bucket(m, MC_BUCKETS))
+
+    print("\n=== Count of stocks by (ratio × mc) bucket ===")
+    pivot_count = df.pivot_table(
+        index="ratio_bucket",
+        columns="mc_bucket",
+        values="return_pct",
+        aggfunc="count",
+        fill_value=0,
+    ).reindex(
+        index=[b[0] for b in RATIO_BUCKETS],
+        columns=[b[0] for b in MC_BUCKETS],
+        fill_value=0,
+    )
+    print(pivot_count.to_string())
+
+    print("\n=== Mean 3-year return % by (ratio × mc) bucket ===")
+    pivot_mean = df.pivot_table(
+        index="ratio_bucket",
+        columns="mc_bucket",
+        values="return_pct",
+        aggfunc="mean",
+    ).reindex(
+        index=[b[0] for b in RATIO_BUCKETS],
+        columns=[b[0] for b in MC_BUCKETS],
+    )
+    print(pivot_mean.round(1).to_string())
+
+    print("\n=== Median 3-year return % by (ratio × mc) bucket ===")
+    pivot_med = df.pivot_table(
+        index="ratio_bucket",
+        columns="mc_bucket",
+        values="return_pct",
+        aggfunc="median",
+    ).reindex(
+        index=[b[0] for b in RATIO_BUCKETS],
+        columns=[b[0] for b in MC_BUCKETS],
+    )
+    print(pivot_med.round(1).to_string())
+
+    print("\n=== Marginal totals (across all market caps) ===")
+    marg = df.groupby("ratio_bucket").agg(
+        n=("return_pct", "count"),
+        mean_ret=("return_pct", "mean"),
+        median_ret=("return_pct", "median"),
+    ).reindex([b[0] for b in RATIO_BUCKETS])
+    print(marg.round(1).to_string())
+
+    # Benchmark comparison
+    with engine.connect() as conn:
+        bench_rows = conn.execute(
+            text(
+                'SELECT "Date", adj_close FROM t_daily_stock_perf '
+                'WHERE "ShokenCode" = \'13060\' '
+                'AND "Date" IN (:entry, :exit_)'
+            ),
+            {"entry": ENTRY_DATE, "exit_": EXIT_DEADLINE},
+        ).fetchall()
+    bench = {r[0]: float(r[1]) for r in bench_rows}
+    if ENTRY_DATE in bench and EXIT_DEADLINE in bench:
+        bench_ret = (bench[EXIT_DEADLINE] / bench[ENTRY_DATE] - 1) * 100
+        print(f"\nTOPIX (1306) 3-year return: {bench_ret:+.1f}%   "
+              f"({ENTRY_DATE}: {bench[ENTRY_DATE]:.2f} → {EXIT_DEADLINE}: {bench[EXIT_DEADLINE]:.2f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/list_3y_returns_smallcap_netcash.py
+++ b/scripts/list_3y_returns_smallcap_netcash.py
@@ -1,0 +1,185 @@
+"""Per-stock 3-year returns for the 2022 cohort matching:
+   - market_cap on 2022-12-30 between ¥15B and ¥50B
+   - net-cash ratio > 1.5 at entry
+   - exit when ratio drops below 1.0, or hold to 2025-12-30
+
+Same exit semantics as cross_table_netcash_2022.py — just emits the
+per-stock list instead of bucketing.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+
+ENTRY_DATE = date(2022, 12, 30)
+EXIT_DEADLINE = date(2025, 12, 30)
+
+MIN_MC = 15_000_000_000
+MAX_MC = 50_000_000_000
+ENTRY_THRESHOLD = 1.5
+EXIT_THRESHOLD = 1.0
+HAIRCUT = 0.7
+
+
+def main():
+    engine = db.get_engine()
+
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" AS sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities, fa.investment_securities,
+                           fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                      AND fa.total_liabilities IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) *
+                    FROM visible ORDER BY sec_code, period_end DESC
+                )
+                SELECT l.sec_code,
+                       COALESCE(em."issuerNameJP", dl_e."filerName") AS company_name,
+                       l.current_assets, l.total_liabilities, l.investment_securities,
+                       l.period_end,
+                       d.adj_close AS entry_price,
+                       d."marketCap" AS entry_mc
+                FROM latest l
+                JOIN t_doc_list dl_e ON dl_e."docID" = l.source_doc_id
+                LEFT JOIN t_edinet_code_mappings em ON em."edinetCode" = dl_e."edinetCode"
+                JOIN t_daily_stock_perf d
+                  ON d."ShokenCode" = l.sec_code AND d."Date" = :entry
+                WHERE d.adj_close IS NOT NULL AND d."marketCap" BETWEEN :min_mc AND :max_mc
+                """
+            ),
+            {"entry": ENTRY_DATE, "min_mc": MIN_MC, "max_mc": MAX_MC},
+        ).fetchall()
+
+    universe = pd.DataFrame(
+        rows,
+        columns=["sec_code", "company_name", "current_assets", "total_liabilities",
+                 "investment_securities", "period_end", "entry_price", "entry_mc"],
+    )
+    for c in ("current_assets", "total_liabilities", "investment_securities", "entry_price", "entry_mc"):
+        universe[c] = universe[c].astype(float)
+    universe["numerator"] = (
+        universe["current_assets"]
+        - universe["total_liabilities"]
+        + HAIRCUT * universe["investment_securities"].fillna(0)
+    )
+    universe["entry_ratio"] = universe["numerator"] / universe["entry_mc"]
+    qualifying = universe[universe["entry_ratio"] > ENTRY_THRESHOLD].reset_index(drop=True)
+    print(f"{len(qualifying)} stocks qualify at entry (mc ¥15-50B, ratio > {ENTRY_THRESHOLD})\n")
+
+    sec_codes = qualifying["sec_code"].tolist()
+    if not sec_codes:
+        return
+
+    with engine.connect() as conn:
+        prices = pd.DataFrame(
+            conn.execute(
+                text(
+                    'SELECT "ShokenCode" AS sec_code, "Date" AS d, adj_close, "marketCap" '
+                    'FROM t_daily_stock_perf '
+                    'WHERE "ShokenCode" = ANY(:codes) AND "Date" BETWEEN :start AND :end '
+                    'AND adj_close IS NOT NULL AND "marketCap" IS NOT NULL '
+                    'ORDER BY "ShokenCode", "Date"'
+                ),
+                {"codes": sec_codes, "start": ENTRY_DATE, "end": EXIT_DEADLINE},
+            ).fetchall(),
+            columns=["sec_code", "d", "adj_close", "market_cap"],
+        )
+    prices["adj_close"] = prices["adj_close"].astype(float)
+    prices["market_cap"] = prices["market_cap"].astype(float)
+
+    with engine.connect() as conn:
+        new_filings = pd.DataFrame(
+            conn.execute(
+                text(
+                    """
+                    SELECT fa."secCode" AS sec_code,
+                           dl."submitDateTime"::date AS submit_date,
+                           fa.current_assets, fa.total_liabilities, fa.investment_securities
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE fa."secCode" = ANY(:codes)
+                      AND dl."submitDateTime"::date BETWEEN :start AND :end
+                      AND fa.current_assets IS NOT NULL AND fa.total_liabilities IS NOT NULL
+                    ORDER BY fa."secCode", dl."submitDateTime"
+                    """
+                ),
+                {"codes": sec_codes, "start": ENTRY_DATE, "end": EXIT_DEADLINE},
+            ).fetchall(),
+            columns=["sec_code", "submit_date", "current_assets", "total_liabilities",
+                     "investment_securities"],
+        )
+    for c in ("current_assets", "total_liabilities", "investment_securities"):
+        new_filings[c] = new_filings[c].astype(float)
+
+    init = qualifying.set_index("sec_code")
+    fbs = {c: g.sort_values("submit_date") for c, g in new_filings.groupby("sec_code")}
+    pbs = {c: g.sort_values("d") for c, g in prices.groupby("sec_code")}
+
+    results = []
+    for sec_code, row in init.iterrows():
+        sp = pbs.get(sec_code)
+        if sp is None or sp.empty:
+            continue
+        numerator = row["numerator"]
+        sf = fbs.get(sec_code, pd.DataFrame())
+        exit_d, exit_p, reason = None, None, "deadline"
+        for _, pr in sp.iterrows():
+            if not sf.empty:
+                applicable = sf[sf["submit_date"] <= pr["d"]]
+                if not applicable.empty:
+                    last = applicable.iloc[-1]
+                    numerator = (
+                        last["current_assets"]
+                        - last["total_liabilities"]
+                        + HAIRCUT * (last["investment_securities"] or 0)
+                    )
+            ratio = numerator / pr["market_cap"] if pr["market_cap"] > 0 else 0
+            if pr["d"] >= ENTRY_DATE and ratio < EXIT_THRESHOLD:
+                exit_d, exit_p, reason = pr["d"], pr["adj_close"], "ratio<1"
+                break
+        if exit_d is None:
+            last = sp.iloc[-1]
+            exit_d, exit_p = last["d"], last["adj_close"]
+        results.append({
+            "sec_code": sec_code,
+            "company": row["company_name"],
+            "entry_ratio": round(row["entry_ratio"], 2),
+            "entry_mc_bn": round(row["entry_mc"] / 1e9, 1),
+            "entry_price": round(row["entry_price"], 0),
+            "exit_date": exit_d,
+            "exit_price": round(exit_p, 0),
+            "days_held": (exit_d - ENTRY_DATE).days,
+            "return_pct": round((exit_p / row["entry_price"] - 1) * 100, 1),
+            "reason": reason,
+        })
+
+    df = pd.DataFrame(results).sort_values("return_pct", ascending=False)
+    print(df.to_string(index=False))
+
+    print(f"\nN = {len(df)}, mean return = {df['return_pct'].mean():.1f}%, "
+          f"median return = {df['return_pct'].median():.1f}%")
+    print(f"Held to deadline: {(df['reason']=='deadline').sum()}, "
+          f"exited via ratio<1: {(df['reason']=='ratio<1').sum()}")
+    print(f"Avg days held: {df['days_held'].mean():.0f} (max possible: 1096)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reparse_for_prior_year.py
+++ b/scripts/reparse_for_prior_year.py
@@ -1,0 +1,132 @@
+"""Re-download and re-parse existing EDINET filings to capture
+Prior1Year* facts that the original ingest did not keep.
+
+The XBRL parser was extended (xbrl_parser.py) to keep
+Prior1YearDuration / Prior1YearInstant contexts alongside the
+CurrentYear* ones we already have. This script re-runs the
+download → parse → upsert path for every securities report whose
+t_financials row set lacks any Prior1Year* row.
+
+Idempotent — once a doc has Prior1Year* rows in t_financials, it's
+skipped on subsequent runs. After re-parsing, also rebuilds the mart
+so the new prior-year mart rows are populated.
+
+Usage:
+    python scripts/reparse_for_prior_year.py 2022-04-25 2023-04-24
+    python scripts/reparse_for_prior_year.py 2023-04-25 2024-04-24
+    python scripts/reparse_for_prior_year.py 2024-04-25 2025-04-24
+    python scripts/reparse_for_prior_year.py 2025-04-25 2026-04-24
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from datetime import date, datetime
+from pathlib import Path
+
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import config, db
+from stock_screening.edinet.client import download_xbrl_bundle
+from stock_screening.edinet.xbrl_parser import extract_facts_many
+from stock_screening.financials.build_annual_mart import build_for_doc
+
+
+def select_pending_docs(engine, start: date, end: date) -> list[str]:
+    """Securities reports submitted in [start, end] that already have
+    CurrentYear* facts but no Prior1Year* facts."""
+    sql = text(
+        """
+        SELECT dl."docID" FROM t_doc_list dl
+        WHERE dl."formCode" = '030000'
+          AND dl."ordinanceCode" = '010'
+          AND dl."submitDateTime"::date BETWEEN :s AND :e
+          AND EXISTS (
+              SELECT 1 FROM t_financials f
+              WHERE f."docID" = dl."docID"
+                AND f."categoryID" IN ('CurrentYearInstant', 'CurrentYearDuration')
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM t_financials f
+              WHERE f."docID" = dl."docID"
+                AND f."categoryID" IN ('Prior1YearInstant', 'Prior1YearDuration')
+          )
+        ORDER BY dl."submitDateTime"
+        """
+    )
+    with engine.connect() as conn:
+        return [r[0] for r in conn.execute(sql, {"s": start, "e": end}).all()]
+
+
+def reparse_one(engine, edinet_key: str, doc_id: str) -> tuple[int, int]:
+    """Returns (facts_inserted, mart_rows_written)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        paths = download_xbrl_bundle(doc_id, edinet_key, Path(tmp))
+        xbrl_files = [p for p in paths if p.suffix == ".xbrl"]
+        if not xbrl_files:
+            return 0, 0
+        facts = [
+            f for f in extract_facts_many(doc_id, xbrl_files) if f.period_end is not None
+        ]
+
+    if not facts:
+        return 0, 0
+
+    rows = [
+        {
+            "docID": f.doc_id, "itemName": f.item_name, "amount": f.amount,
+            "periodStart": f.period_start, "periodEnd": f.period_end,
+            "categoryID": f.category_id, "concept_id": f.concept_id,
+            "currency_code": f.currency_code,
+        }
+        for f in facts
+    ]
+    sql = text(
+        """
+        INSERT INTO t_financials
+            ("docID","itemName",amount,"periodStart","periodEnd","categoryID",concept_id,currency_code)
+        VALUES (:docID,:itemName,:amount,:periodStart,:periodEnd,:categoryID,:concept_id,:currency_code)
+        ON CONFLICT ("docID","itemName","periodEnd","categoryID")
+        DO UPDATE SET amount=EXCLUDED.amount, concept_id=EXCLUDED.concept_id, currency_code=EXCLUDED.currency_code
+        """
+    )
+    with engine.begin() as conn:
+        conn.execute(sql, rows)
+
+    mart_n = build_for_doc(engine, doc_id)
+    return len(facts), mart_n
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: reparse_for_prior_year.py START END", file=sys.stderr)
+        sys.exit(1)
+    start = datetime.strptime(sys.argv[1], "%Y-%m-%d").date()
+    end = datetime.strptime(sys.argv[2], "%Y-%m-%d").date()
+
+    engine = db.get_engine()
+    edinet_key = config.edinet_key()
+
+    docs = select_pending_docs(engine, start, end)
+    print(f"{len(docs)} docs to re-parse for {start} → {end}")
+
+    total_facts = 0
+    total_mart = 0
+    for i, doc_id in enumerate(docs, 1):
+        try:
+            n_facts, n_mart = reparse_one(engine, edinet_key, doc_id)
+            total_facts += n_facts
+            total_mart += n_mart
+            if i % 50 == 0 or i == len(docs):
+                print(f"  [{i}/{len(docs)}] last: {doc_id} facts={n_facts}, mart_rows={n_mart}")
+        except Exception as e:
+            print(f"  [warn] {doc_id} failed: {type(e).__name__}: {str(e)[:120]}")
+
+    print(f"\nfinished. total facts inserted: {total_facts}, mart rows written: {total_mart}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stock_screening/edinet/xbrl_parser.py
+++ b/src/stock_screening/edinet/xbrl_parser.py
@@ -16,9 +16,17 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# Categories we care about. CurrentYear* is the filer's reported period
-# (vs PriorYear* for the comparative).
-RELEVANT_CATEGORIES = ("CurrentYearDuration", "CurrentYearInstant")
+# Categories we care about. CurrentYear* is the filer's reported period;
+# Prior1Year* is the comparative shown alongside in the same filing —
+# free prior-year data that lets the mart build trend metrics
+# (op income YoY, sales YoY, margin change) without needing the
+# previous year's actual filing in our doclist.
+RELEVANT_CATEGORIES = (
+    "CurrentYearDuration",
+    "CurrentYearInstant",
+    "Prior1YearDuration",
+    "Prior1YearInstant",
+)
 
 
 @dataclass

--- a/src/stock_screening/financials/build_annual_mart.py
+++ b/src/stock_screening/financials/build_annual_mart.py
@@ -1,10 +1,16 @@
 """Project raw EAV (t_financials) → typed t_financials_annual.
 
-For each (secCode, period_end), pick the latest filing (via
-t_doc_list.is_latest_for_period) and pivot its facts onto the typed
-columns of t_financials_annual. The interest_bearing_debt column on
-the mart is GENERATED STORED, so we don't compute it here — Postgres
-sums the components automatically.
+Each annual filing yields *two* mart rows:
+  - one for the current fiscal year (period_end = doc's periodEnd),
+    built from CurrentYear* facts.
+  - one for the prior fiscal year (period_end = doc's periodEnd − 1y),
+    built from Prior1Year* facts that the same filing carries in its
+    Summary-of-Business-Results table.
+
+This means a single FY2024 annual report populates BOTH FY2023 and
+FY2024 mart rows, even if we never ingested the actual FY2023 filing.
+The interest_bearing_debt column is a GENERATED STORED sum of the
+debt components; Postgres maintains it on insert/update.
 """
 
 from __future__ import annotations
@@ -12,6 +18,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Iterable
+from datetime import date
 
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
@@ -23,34 +30,95 @@ logger = logging.getLogger(__name__)
 MART_FIELDS = tuple(cm.field_name for cm in CONCEPTS)
 
 
-def _fetch_latest_facts_for_doc(engine: Engine, doc_id: str) -> list[dict]:
-    """Return every CurrentYear* fact for a doc.
-
-    Includes both Instant (balance-sheet snapshots) and Duration (income-
-    statement flows). Duration facts have a period_start AND period_end;
-    for an annual filing, period_end matches the balance-sheet date, so
-    income-statement items collapse onto the same mart row as the
-    balance-sheet items.
-    """
+def _fetch_facts_for_doc(
+    engine: Engine, doc_id: str, categories: tuple[str, ...]
+) -> list[dict]:
+    """Return facts for a doc filtered to the given XBRL category set
+    (e.g. CurrentYear* for the current period, Prior1Year* for the
+    comparative)."""
     sql = text(
         """
         SELECT "docID" AS doc_id, "itemName" AS item_name, amount,
                "periodEnd" AS period_end, concept_id
         FROM t_financials
-        WHERE "docID" = :doc_id
-          AND "categoryID" IN ('CurrentYearInstant', 'CurrentYearDuration')
+        WHERE "docID" = :doc_id AND "categoryID" = ANY(:cats)
         """
     )
     with engine.connect() as conn:
-        return [dict(r) for r in conn.execute(sql, {"doc_id": doc_id}).mappings()]
+        return [
+            dict(r)
+            for r in conn.execute(
+                sql, {"doc_id": doc_id, "cats": list(categories)}
+            ).mappings()
+        ]
+
+
+def _pivot(facts: list[dict]) -> dict[str, float]:
+    """Resolve concept ID / label to mart field, picking the larger-
+    magnitude fact when multiple map to the same field (handles
+    consolidated vs non-consolidated)."""
+    pivoted: dict[str, float] = {}
+    seen: dict[str, float] = defaultdict(lambda: -1.0)
+    for f in facts:
+        field = resolve_field(f.get("concept_id"), f.get("item_name"))
+        if field is None or f.get("amount") is None:
+            continue
+        amt = float(f["amount"])
+        if abs(amt) > seen[field]:
+            seen[field] = abs(amt)
+            pivoted[field] = amt
+    return pivoted
+
+
+def _upsert_mart_row(
+    engine: Engine,
+    sec_code: str,
+    period_end: date,
+    fiscal_year_end_dt: date | None,
+    source_doc_id: str,
+    pivoted: dict[str, float],
+) -> int:
+    if not pivoted:
+        return 0
+    cols = ["secCode", "period_end", "fiscal_year_end_dt", "source_doc_id", *MART_FIELDS]
+    values = {
+        "secCode": sec_code,
+        "period_end": period_end,
+        "fiscal_year_end_dt": fiscal_year_end_dt,
+        "source_doc_id": source_doc_id,
+        **{f: pivoted.get(f) for f in MART_FIELDS},
+    }
+    placeholders = ", ".join(f":{c}" for c in cols)
+    quoted_cols = ", ".join(f'"{c}"' if c == "secCode" else c for c in cols)
+    update_set = ", ".join(
+        f"{c} = EXCLUDED.{c}" for c in cols if c not in ("secCode", "period_end")
+    )
+    sql = text(
+        f"""
+        INSERT INTO t_financials_annual ({quoted_cols})
+        VALUES ({placeholders})
+        ON CONFLICT ("secCode", period_end) DO UPDATE SET {update_set}
+        """
+    )
+    with engine.begin() as conn:
+        conn.execute(sql, values)
+    return 1
+
+
+def _prior_period_end(period_end: date) -> date:
+    """One year before period_end. Handles Feb 29 by stepping back to
+    Feb 28 in non-leap years."""
+    try:
+        return period_end.replace(year=period_end.year - 1)
+    except ValueError:  # Feb 29
+        return period_end.replace(month=2, day=28, year=period_end.year - 1)
 
 
 def build_for_doc(engine: Engine, doc_id: str) -> int:
-    """Build / refresh the t_financials_annual row for the (secCode,
-    period_end) of a single filing. Idempotent: upserts.
+    """Build / refresh up to TWO t_financials_annual rows for a filing:
+    one for the current fiscal year, one for the prior. Idempotent.
 
-    Returns 1 if a row was written, 0 if the doc had no relevant facts
-    or no secCode.
+    Returns count of rows written (0, 1, or 2).
     """
     with engine.connect() as conn:
         meta = conn.execute(
@@ -66,52 +134,28 @@ def build_for_doc(engine: Engine, doc_id: str) -> int:
     if meta is None or not meta["secCode"] or not meta["periodEnd"]:
         return 0
 
-    facts = _fetch_latest_facts_for_doc(engine, doc_id)
-    if not facts:
-        return 0
+    sec_code = str(meta["secCode"])
+    period_end = meta["periodEnd"]
+    fy_end = meta["endOfFiscalYearDt"]
 
-    # Pivot: pick the largest absolute amount when multiple facts map to
-    # the same field (handles consolidated vs non-consolidated; consolidated
-    # is typically the larger figure).
-    pivoted: dict[str, float] = {}
-    seen: dict[str, float] = defaultdict(lambda: -1.0)
-    for f in facts:
-        field = resolve_field(f.get("concept_id"), f.get("item_name"))
-        if field is None or f.get("amount") is None:
-            continue
-        amt = float(f["amount"])
-        if abs(amt) > seen[field]:
-            seen[field] = abs(amt)
-            pivoted[field] = amt
+    n_written = 0
 
-    if not pivoted:
-        return 0
-
-    cols = ["secCode", "period_end", "fiscal_year_end_dt", "source_doc_id", *MART_FIELDS]
-    values = {
-        "secCode": str(meta["secCode"]),
-        "period_end": meta["periodEnd"],
-        "fiscal_year_end_dt": meta["endOfFiscalYearDt"],
-        "source_doc_id": doc_id,
-        **{f: pivoted.get(f) for f in MART_FIELDS},
-    }
-
-    placeholders = ", ".join(f":{c}" for c in cols)
-    quoted_cols = ", ".join(f'"{c}"' if c == "secCode" else c for c in cols)
-    update_set = ", ".join(
-        f"{c} = EXCLUDED.{c}" for c in cols if c not in ("secCode", "period_end")
+    current_facts = _fetch_facts_for_doc(
+        engine, doc_id, ("CurrentYearInstant", "CurrentYearDuration")
+    )
+    n_written += _upsert_mart_row(
+        engine, sec_code, period_end, fy_end, doc_id, _pivot(current_facts)
     )
 
-    sql = text(
-        f"""
-        INSERT INTO t_financials_annual ({quoted_cols})
-        VALUES ({placeholders})
-        ON CONFLICT ("secCode", period_end) DO UPDATE SET {update_set}
-        """
+    prior_facts = _fetch_facts_for_doc(
+        engine, doc_id, ("Prior1YearInstant", "Prior1YearDuration")
     )
-    with engine.begin() as conn:
-        conn.execute(sql, values)
-    return 1
+    n_written += _upsert_mart_row(
+        engine, sec_code, _prior_period_end(period_end), fy_end, doc_id,
+        _pivot(prior_facts),
+    )
+
+    return n_written
 
 
 def build_for_docs(engine: Engine, doc_ids: Iterable[str]) -> int:

--- a/src/stock_screening/financials/build_annual_mart.py
+++ b/src/stock_screening/financials/build_annual_mart.py
@@ -24,15 +24,21 @@ MART_FIELDS = tuple(cm.field_name for cm in CONCEPTS)
 
 
 def _fetch_latest_facts_for_doc(engine: Engine, doc_id: str) -> list[dict]:
-    """Return every CurrentYearInstant fact for a doc — these are the
-    balance-sheet line items the screen cares about."""
+    """Return every CurrentYear* fact for a doc.
+
+    Includes both Instant (balance-sheet snapshots) and Duration (income-
+    statement flows). Duration facts have a period_start AND period_end;
+    for an annual filing, period_end matches the balance-sheet date, so
+    income-statement items collapse onto the same mart row as the
+    balance-sheet items.
+    """
     sql = text(
         """
         SELECT "docID" AS doc_id, "itemName" AS item_name, amount,
                "periodEnd" AS period_end, concept_id
         FROM t_financials
         WHERE "docID" = :doc_id
-          AND "categoryID" = 'CurrentYearInstant'
+          AND "categoryID" IN ('CurrentYearInstant', 'CurrentYearDuration')
         """
     )
     with engine.connect() as conn:

--- a/src/stock_screening/financials/concepts.py
+++ b/src/stock_screening/financials/concepts.py
@@ -92,6 +92,17 @@ CONCEPTS: tuple[ConceptMap, ...] = (
         labels=("資産合計", "総資産額"),
     ),
     ConceptMap(
+        field_name="net_sales",
+        # CurrentYearDuration income-statement fact (top line). Used by
+        # the turnaround signal alongside operating_income to distinguish
+        # revenue-growing recoveries from cost-cut-only "fake" turnarounds.
+        concept_ids=(
+            "jpcrp_cor:NetSalesSummaryOfBusinessResults",
+            "jppfs_cor:NetSales",
+        ),
+        labels=("売上高",),
+    ),
+    ConceptMap(
         field_name="operating_income",
         # CurrentYearDuration income-statement fact. Used by the screen
         # to filter for "solid profitability" alongside net-cash level.

--- a/src/stock_screening/financials/concepts.py
+++ b/src/stock_screening/financials/concepts.py
@@ -92,6 +92,19 @@ CONCEPTS: tuple[ConceptMap, ...] = (
         labels=("資産合計", "総資産額"),
     ),
     ConceptMap(
+        field_name="operating_income",
+        # CurrentYearDuration income-statement fact. Used by the screen
+        # to filter for "solid profitability" alongside net-cash level.
+        # The Summary form is in the 5-year highlights table; the
+        # consolidated statement of operations form is preferred when
+        # both are emitted (mart pivot picks the larger absolute value).
+        concept_ids=(
+            "jpcrp_cor:OperatingIncomeSummaryOfBusinessResults",
+            "jppfs_cor:OperatingIncome",
+        ),
+        labels=("営業利益", "営業利益又は営業損失（△）"),
+    ),
+    ConceptMap(
         field_name="issued_shares",
         # Verified against real filings — this is the concept used in
         # 有報's "shares issued / voting rights" section. Total issued

--- a/src/stock_screening/screening/metrics.py
+++ b/src/stock_screening/screening/metrics.py
@@ -1,34 +1,37 @@
-"""Net-cash ratio screen.
+"""Net-cash-plus-quality screen.
 
-Formula (market-cap based, conservative form):
-    ratio = (current_assets - total_liabilities + 0.7*investment_securities)
-            / market_cap
-qualifies = ratio >= 1.0
+A stock qualifies if all three are true:
 
-NOTE on liabilities: we use `total_liabilities` (負債合計) rather than
-`interest_bearing_debt` (有利子負債) — even though the canonical
-ネットキャッシュ比率 textbook uses interest-bearing debt — because
-empirical quintile analysis on our data and a 1,800-stock 3-year
-study (https://zenn.dev/morim34/articles/ff991f32187d96) both show
-that total_liabilities produces a cleaner monotonic relationship
-between ratio and forward return. The interest-bearing-debt form has
-a Q5-collapse artifact: companies with no bank debt but huge trade
-payables / accruals (operating distress) score artificially high.
+1. **Net-cash ratio ≥ 1.0** — `(current_assets − total_liabilities +
+   0.7 × investment_securities) / market_cap`. Conservative form of the
+   ネットキャッシュ比率: uses total liabilities (負債合計) rather than
+   interest-bearing debt (有利子負債). Empirically — see quintile
+   analysis on our data and a 1,800-stock 3-year study at
+   https://zenn.dev/morim34/articles/ff991f32187d96 — total_liabilities
+   produces a cleaner monotonic relationship between ratio and forward
+   return. The interest-bearing-debt form has a Q5-collapse artifact:
+   companies with no bank debt but huge trade payables / accruals
+   (operating distress) score artificially high.
 
-The mart still stores both — interest_bearing_debt remains as a
-GENERATED column from short_term_borrowings + long_term_borrowings +
-bonds + lease_obligations — so it's available for diagnostic queries
-and alternative strategies. The screen here uses total_liabilities.
+2. **Operating-income yield > 5%** — `operating_income / market_cap`.
+   Catches value traps with structurally net cash but stagnant or
+   declining operations (e.g. companies whose earnings power is a tiny
+   fraction of their cash hoard). Threshold tuned from the 2022-cohort
+   3-year analysis: > 5% catches 3 of 5 worst-trap cases at the cost
+   of only 1 turnaround winner.
 
-Reads from t_financials_annual joined with t_daily_stock_perf for
-the run date's market_cap. For each company, picks the most recent
-annual filing with period_end <= run_date.
+3. **6-month price momentum > 0%** — adj-close change vs the closest
+   trading day ~180 days before run_date. Adds a "market is starting
+   to wake up to this" check. Modest improvement over net-cash alone.
+
+The mart still stores `interest_bearing_debt` as a GENERATED column;
+it's diagnostic, not used by this screen.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, timedelta
 
 import pandas as pd
 from sqlalchemy import text
@@ -36,6 +39,9 @@ from sqlalchemy.engine import Engine
 
 QUALIFY_THRESHOLD = 1.0
 INVESTMENT_SECURITIES_HAIRCUT = 0.7
+OP_YIELD_THRESHOLD = 0.05            # operating_income / market_cap > 5%
+MOMENTUM_THRESHOLD = 0.0             # 6-month price return > 0%
+MOMENTUM_LOOKBACK_DAYS = 180
 
 
 @dataclass
@@ -55,7 +61,8 @@ _SCREEN_SQL = text(
             fa.period_end AS source_period_end,
             fa.current_assets,
             fa.total_liabilities,
-            fa.investment_securities
+            fa.investment_securities,
+            fa.operating_income
         FROM t_financials_annual fa
         WHERE fa.period_end <= :run_date
         ORDER BY fa."secCode", fa.period_end DESC
@@ -66,11 +73,22 @@ _SCREEN_SQL = text(
         l.current_assets,
         l.total_liabilities,
         l.investment_securities,
-        d."marketCap" AS market_cap
+        l.operating_income,
+        d."marketCap" AS market_cap,
+        d.adj_close AS close_now,
+        prior.adj_close AS close_180d_ago
     FROM latest l
     JOIN t_daily_stock_perf d
       ON d."ShokenCode" = l.sec_code
      AND d."Date" = :run_date
+    LEFT JOIN LATERAL (
+        SELECT adj_close
+        FROM t_daily_stock_perf p
+        WHERE p."ShokenCode" = l.sec_code
+          AND p."Date" BETWEEN :lookback_start AND :lookback_end
+          AND p.adj_close IS NOT NULL
+        ORDER BY p."Date" DESC LIMIT 1
+    ) prior ON TRUE
     WHERE d."marketCap" IS NOT NULL
       AND d."marketCap" > 0
     """
@@ -78,24 +96,39 @@ _SCREEN_SQL = text(
 
 
 def compute_screen(engine: Engine, run_date: date) -> pd.DataFrame:
-    """Run the screen for `run_date`, return one row per scoreable
-    company with the ratio and qualifies flag.
+    """Run the screen for `run_date`. Returns one row per scoreable
+    company with all three filter components computed and a combined
+    `qualifies` flag.
     """
+    params = {
+        "run_date": run_date,
+        "lookback_start": run_date - timedelta(days=MOMENTUM_LOOKBACK_DAYS + 20),
+        "lookback_end": run_date - timedelta(days=MOMENTUM_LOOKBACK_DAYS - 20),
+    }
     with engine.connect() as conn:
-        rows = conn.execute(_SCREEN_SQL, {"run_date": run_date}).fetchall()
+        rows = conn.execute(_SCREEN_SQL, params).fetchall()
 
     cols = [
         "sec_code", "source_period_end", "current_assets",
-        "total_liabilities", "investment_securities", "market_cap",
+        "total_liabilities", "investment_securities", "operating_income",
+        "market_cap", "close_now", "close_180d_ago",
     ]
     df = pd.DataFrame(rows, columns=cols)
 
     if df.empty:
-        return df.assign(ratio=pd.Series(dtype=float), qualifies=pd.Series(dtype=bool))
+        return df.assign(
+            ratio=pd.Series(dtype=float),
+            op_yield=pd.Series(dtype=float),
+            momentum_6m=pd.Series(dtype=float),
+            qualifies=pd.Series(dtype=bool),
+        )
 
-    # SA1.4 returns Decimal for NUMERIC columns; cast to float for arithmetic.
-    for col in ("current_assets", "total_liabilities", "investment_securities", "market_cap"):
-        df[col] = df[col].astype(float)
+    # SA1.4 returns Decimal for NUMERIC columns; cast for arithmetic.
+    for col in (
+        "current_assets", "total_liabilities", "investment_securities",
+        "operating_income", "market_cap", "close_now", "close_180d_ago",
+    ):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
 
     df["ratio"] = (
         df["current_assets"].fillna(0)
@@ -103,7 +136,15 @@ def compute_screen(engine: Engine, run_date: date) -> pd.DataFrame:
         + INVESTMENT_SECURITIES_HAIRCUT * df["investment_securities"].fillna(0)
     ) / df["market_cap"]
 
-    df["qualifies"] = df["ratio"] >= QUALIFY_THRESHOLD
+    df["op_yield"] = df["operating_income"] / df["market_cap"]
+    df["momentum_6m"] = (df["close_now"] / df["close_180d_ago"]) - 1
+
+    df["qualifies"] = (
+        (df["ratio"] >= QUALIFY_THRESHOLD)
+        & (df["op_yield"] > OP_YIELD_THRESHOLD)
+        & (df["momentum_6m"] > MOMENTUM_THRESHOLD)
+    ).fillna(False)
+
     return df
 
 

--- a/src/stock_screening/screening/metrics.py
+++ b/src/stock_screening/screening/metrics.py
@@ -181,3 +181,87 @@ def persist_screen_results(engine: Engine, run_date: date, df: pd.DataFrame) -> 
     with engine.begin() as conn:
         conn.execute(sql, rows)
     return len(rows)
+
+
+# --- Turnaround signal --------------------------------------------------
+#
+# A turnaround candidate is a stock whose operations are *recovering* —
+# distinct from a value trap (cheap and stagnant). Three companion
+# measurements off the multi-year mart:
+#
+#   op_income_yoy  = (op_income_now - op_income_prev) / |op_income_prev|
+#   sales_yoy      = (net_sales_now - net_sales_prev) / net_sales_prev
+#   margin_change  = (op_income_now / net_sales_now)
+#                  - (op_income_prev / net_sales_prev)
+#
+# Combined judgment:
+#   - op_income_yoy > 0.20 AND sales_yoy > 0:  real recovery
+#   - op_income_yoy > 0.20 AND sales_yoy <= 0: cost-cut driven (often fragile)
+#   - op_income_yoy <= 0:                       not turning around
+#
+# Returns NaN for companies with fewer than 2 visible filings — common
+# for our pre-2024 backtests since financials backfill starts at 2022-04-25
+# (most TSE companies have only one filing visible until 2024 when their
+# FY2023 reports land).
+
+_TURNAROUND_SQL = text(
+    """
+    WITH visible AS (
+        SELECT fa."secCode", fa.period_end,
+               fa.operating_income, fa.net_sales
+        FROM t_financials_annual fa
+        WHERE fa.period_end <= :run_date
+    ),
+    ranked AS (
+        SELECT "secCode", period_end, operating_income, net_sales,
+               LAG(operating_income) OVER w AS op_income_prev,
+               LAG(net_sales) OVER w AS net_sales_prev,
+               LAG(period_end) OVER w AS period_end_prev
+        FROM visible
+        WINDOW w AS (PARTITION BY "secCode" ORDER BY period_end)
+    )
+    SELECT DISTINCT ON ("secCode")
+        "secCode" AS sec_code, period_end, period_end_prev,
+        operating_income, op_income_prev,
+        net_sales, net_sales_prev
+    FROM ranked
+    WHERE op_income_prev IS NOT NULL OR net_sales_prev IS NOT NULL
+    ORDER BY "secCode", period_end DESC
+    """
+)
+
+
+def compute_turnaround_score(engine: Engine, run_date: date) -> pd.DataFrame:
+    """For each company with ≥2 visible annual filings by run_date,
+    return YoY changes in op income, sales, and operating margin.
+    Companies with insufficient history are absent from the output.
+    """
+    with engine.connect() as conn:
+        rows = conn.execute(_TURNAROUND_SQL, {"run_date": run_date}).fetchall()
+
+    cols = [
+        "sec_code", "period_end", "period_end_prev",
+        "operating_income", "op_income_prev",
+        "net_sales", "net_sales_prev",
+    ]
+    df = pd.DataFrame(rows, columns=cols)
+    if df.empty:
+        return df.assign(
+            op_income_yoy=pd.Series(dtype=float),
+            sales_yoy=pd.Series(dtype=float),
+            margin_change=pd.Series(dtype=float),
+        )
+
+    for c in ("operating_income", "op_income_prev", "net_sales", "net_sales_prev"):
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+
+    df["op_income_yoy"] = (df["operating_income"] - df["op_income_prev"]) / df[
+        "op_income_prev"
+    ].abs()
+    df["sales_yoy"] = (df["net_sales"] - df["net_sales_prev"]) / df["net_sales_prev"]
+
+    margin_now = df["operating_income"] / df["net_sales"]
+    margin_prev = df["op_income_prev"] / df["net_sales_prev"]
+    df["margin_change"] = margin_now - margin_prev
+
+    return df

--- a/src/stock_screening/screening/metrics.py
+++ b/src/stock_screening/screening/metrics.py
@@ -1,14 +1,28 @@
 """Net-cash ratio screen.
 
-Formula (canonical Japanese ネットキャッシュ比率, market-cap based):
-    ratio = (current_assets - interest_bearing_debt + 0.7*investment_securities)
+Formula (market-cap based, conservative form):
+    ratio = (current_assets - total_liabilities + 0.7*investment_securities)
             / market_cap
 qualifies = ratio >= 1.0
 
-Reads from t_financials_annual (typed columns; debt is the GENERATED
-sum of components) joined with t_daily_stock_perf for the run date's
-market_cap. For each company, picks the most recent annual filing
-with period_end <= run_date.
+NOTE on liabilities: we use `total_liabilities` (負債合計) rather than
+`interest_bearing_debt` (有利子負債) — even though the canonical
+ネットキャッシュ比率 textbook uses interest-bearing debt — because
+empirical quintile analysis on our data and a 1,800-stock 3-year
+study (https://zenn.dev/morim34/articles/ff991f32187d96) both show
+that total_liabilities produces a cleaner monotonic relationship
+between ratio and forward return. The interest-bearing-debt form has
+a Q5-collapse artifact: companies with no bank debt but huge trade
+payables / accruals (operating distress) score artificially high.
+
+The mart still stores both — interest_bearing_debt remains as a
+GENERATED column from short_term_borrowings + long_term_borrowings +
+bonds + lease_obligations — so it's available for diagnostic queries
+and alternative strategies. The screen here uses total_liabilities.
+
+Reads from t_financials_annual joined with t_daily_stock_perf for
+the run date's market_cap. For each company, picks the most recent
+annual filing with period_end <= run_date.
 """
 
 from __future__ import annotations
@@ -40,7 +54,7 @@ _SCREEN_SQL = text(
             fa."secCode" AS sec_code,
             fa.period_end AS source_period_end,
             fa.current_assets,
-            fa.interest_bearing_debt,
+            fa.total_liabilities,
             fa.investment_securities
         FROM t_financials_annual fa
         WHERE fa.period_end <= :run_date
@@ -50,7 +64,7 @@ _SCREEN_SQL = text(
         l.sec_code,
         l.source_period_end,
         l.current_assets,
-        l.interest_bearing_debt,
+        l.total_liabilities,
         l.investment_securities,
         d."marketCap" AS market_cap
     FROM latest l
@@ -72,7 +86,7 @@ def compute_screen(engine: Engine, run_date: date) -> pd.DataFrame:
 
     cols = [
         "sec_code", "source_period_end", "current_assets",
-        "interest_bearing_debt", "investment_securities", "market_cap",
+        "total_liabilities", "investment_securities", "market_cap",
     ]
     df = pd.DataFrame(rows, columns=cols)
 
@@ -80,12 +94,12 @@ def compute_screen(engine: Engine, run_date: date) -> pd.DataFrame:
         return df.assign(ratio=pd.Series(dtype=float), qualifies=pd.Series(dtype=bool))
 
     # SA1.4 returns Decimal for NUMERIC columns; cast to float for arithmetic.
-    for col in ("current_assets", "interest_bearing_debt", "investment_securities", "market_cap"):
+    for col in ("current_assets", "total_liabilities", "investment_securities", "market_cap"):
         df[col] = df[col].astype(float)
 
     df["ratio"] = (
         df["current_assets"].fillna(0)
-        - df["interest_bearing_debt"].fillna(0)
+        - df["total_liabilities"].fillna(0)
         + INVESTMENT_SECURITIES_HAIRCUT * df["investment_securities"].fillna(0)
     ) / df["market_cap"]
 

--- a/src/stock_screening/simulation/portfolio.py
+++ b/src/stock_screening/simulation/portfolio.py
@@ -31,41 +31,47 @@ class PortfolioSnapshot:
         return {row.secCode: int(row.shares) for row in self.positions.itertuples()}
 
 
-def delete_outputs_for_date(engine: Engine, run_date: date) -> None:
-    """Idempotency hook for backfill / re-runs."""
+def delete_outputs_for_date(engine: Engine, run_date: date, strategy_name: str) -> None:
+    """Idempotency hook for backfill / re-runs. Scoped to one strategy
+    so re-running strategy A doesn't wipe strategy B's outputs."""
     with engine.begin() as conn:
         for table, col in (
             ("t_sim_positions", "as_of_date"),
             ("t_sim_trades", "trade_date"),
             ("t_sim_portfolio_nav", "as_of_date"),
         ):
-            conn.execute(text(f"DELETE FROM {table} WHERE {col} = :d"), {"d": run_date})
+            conn.execute(
+                text(f"DELETE FROM {table} WHERE {col} = :d AND strategy_name = :s"),
+                {"d": run_date, "s": strategy_name},
+            )
 
 
-def load_previous_snapshot(engine: Engine, before_date: date) -> PortfolioSnapshot | None:
-    """Most recent NAV snapshot strictly before `before_date`. Returns
-    None on a cold start (no prior runs).
+def load_previous_snapshot(
+    engine: Engine, before_date: date, strategy_name: str
+) -> PortfolioSnapshot | None:
+    """Most recent NAV snapshot strictly before `before_date` for the
+    given strategy. Returns None on a cold start.
     """
     with engine.connect() as conn:
         nav_row = conn.execute(
             text(
                 "SELECT as_of_date, cash, positions_value, total_nav, n_positions "
-                "FROM t_sim_portfolio_nav WHERE as_of_date < :d "
+                "FROM t_sim_portfolio_nav "
+                "WHERE as_of_date < :d AND strategy_name = :s "
                 "ORDER BY as_of_date DESC LIMIT 1"
             ),
-            {"d": before_date},
+            {"d": before_date, "s": strategy_name},
         ).mappings().first()
         if nav_row is None:
             return None
 
-        # SA1.4 connection objects don't satisfy pandas 2.2's read_sql
-        # contract; fetch and build the DataFrame manually.
         prows = conn.execute(
             text(
                 'SELECT "secCode", shares, avg_cost, last_price, market_value '
-                "FROM t_sim_positions WHERE as_of_date = :d"
+                "FROM t_sim_positions "
+                "WHERE as_of_date = :d AND strategy_name = :s"
             ),
-            {"d": nav_row["as_of_date"]},
+            {"d": nav_row["as_of_date"], "s": strategy_name},
         ).fetchall()
         positions = pd.DataFrame(
             prows,
@@ -148,11 +154,14 @@ def apply_trades(
     return pos.reset_index(), new_cash
 
 
-def persist_positions(engine: Engine, as_of_date: date, positions: pd.DataFrame) -> int:
+def persist_positions(
+    engine: Engine, as_of_date: date, positions: pd.DataFrame, strategy_name: str
+) -> int:
     if positions.empty:
         return 0
     rows = [
         {
+            "strategy_name": strategy_name,
             "as_of_date": as_of_date,
             "secCode": r["secCode"],
             "shares": int(r["shares"]),
@@ -165,8 +174,8 @@ def persist_positions(engine: Engine, as_of_date: date, positions: pd.DataFrame)
     sql = text(
         """
         INSERT INTO t_sim_positions
-            (as_of_date, "secCode", shares, avg_cost, last_price, market_value)
-        VALUES (:as_of_date, :secCode, :shares, :avg_cost, :last_price, :market_value)
+            (strategy_name, as_of_date, "secCode", shares, avg_cost, last_price, market_value)
+        VALUES (:strategy_name, :as_of_date, :secCode, :shares, :avg_cost, :last_price, :market_value)
         """
     )
     with engine.begin() as conn:
@@ -174,11 +183,14 @@ def persist_positions(engine: Engine, as_of_date: date, positions: pd.DataFrame)
     return len(rows)
 
 
-def persist_trades(engine: Engine, trade_date: date, trades: list[Trade]) -> int:
+def persist_trades(
+    engine: Engine, trade_date: date, trades: list[Trade], strategy_name: str
+) -> int:
     if not trades:
         return 0
     rows = [
         {
+            "strategy_name": strategy_name,
             "trade_date": trade_date,
             "secCode": t.sec_code,
             "side": t.side,
@@ -192,8 +204,8 @@ def persist_trades(engine: Engine, trade_date: date, trades: list[Trade]) -> int
     sql = text(
         """
         INSERT INTO t_sim_trades
-            (trade_date, "secCode", side, shares, price, commission, reason)
-        VALUES (:trade_date, :secCode, :side, :shares, :price, :commission, :reason)
+            (strategy_name, trade_date, "secCode", side, shares, price, commission, reason)
+        VALUES (:strategy_name, :trade_date, :secCode, :side, :shares, :price, :commission, :reason)
         """
     )
     with engine.begin() as conn:
@@ -207,20 +219,22 @@ def persist_nav(
     cash: float,
     positions: pd.DataFrame,
     benchmark_nav: float | None,
+    strategy_name: str,
 ) -> None:
     pos_value = float(positions["market_value"].sum()) if not positions.empty else 0.0
     n = int(len(positions))
     sql = text(
         """
         INSERT INTO t_sim_portfolio_nav
-            (as_of_date, cash, positions_value, total_nav, benchmark_nav, n_positions)
-        VALUES (:as_of_date, :cash, :positions_value, :total_nav, :benchmark_nav, :n)
+            (strategy_name, as_of_date, cash, positions_value, total_nav, benchmark_nav, n_positions)
+        VALUES (:strategy_name, :as_of_date, :cash, :positions_value, :total_nav, :benchmark_nav, :n)
         """
     )
     with engine.begin() as conn:
         conn.execute(
             sql,
             {
+                "strategy_name": strategy_name,
                 "as_of_date": as_of_date,
                 "cash": cash,
                 "positions_value": pos_value,

--- a/src/stock_screening/simulation/rebalance.py
+++ b/src/stock_screening/simulation/rebalance.py
@@ -34,15 +34,19 @@ class Trade:
 
 
 def select_target_names(
-    qualifying: pd.DataFrame, current: Sequence[str], max_positions: int
+    qualifying: pd.DataFrame,
+    current: Sequence[str],
+    max_positions: int,
+    swap_rule: str = "strict_improvement",
 ) -> list[str]:
     """Pick which names to hold tomorrow.
 
-    qualifying: columns sec_code, ratio (sorted or not, both fine).
-    current: sec_codes held today.
-    Rule: keep current names that still qualify; fill remaining slots
-    with non-held names that have a strictly better ratio than the
-    weakest held name. Preserves stability.
+    swap_rule:
+      'strict_improvement' — keep held names that qualify; fill open
+        slots with top non-held; only displace a held name when a
+        non-held has a STRICTLY better ratio (anti-thrashing).
+      'full_rebalance' — ignore current holdings; target = top N by
+        ratio. Higher turnover; surfaces noise vs signal in costs.
     """
     if qualifying.empty:
         return []
@@ -50,26 +54,25 @@ def select_target_names(
     df = qualifying[["sec_code", "ratio"]].sort_values(
         "ratio", ascending=False
     ).reset_index(drop=True)
-    ratios = dict(zip(df["sec_code"], df["ratio"], strict=True))
 
+    if swap_rule == "full_rebalance":
+        return df["sec_code"].head(max_positions).tolist()
+
+    if swap_rule != "strict_improvement":
+        raise ValueError(f"unknown swap_rule: {swap_rule}")
+
+    ratios = dict(zip(df["sec_code"], df["ratio"], strict=True))
     held_qualifying = [c for c in current if c in ratios]
     chosen = list(held_qualifying)
-
     candidates = [c for c in df["sec_code"] if c not in set(chosen)]
 
-    # Fill open slots first — drops in qualifying universe shouldn't be
-    # blocked by the strict-improvement rule.
     while len(chosen) < max_positions and candidates:
         chosen.append(candidates.pop(0))
 
-    # If still over max (shouldn't happen unless current > max), trim worst.
     if len(chosen) > max_positions:
         chosen.sort(key=lambda c: ratios[c], reverse=True)
         chosen = chosen[:max_positions]
 
-    # Strict-improvement swap: replace the weakest chosen with the next
-    # candidate iff candidate's ratio is STRICTLY greater. Equal ratios
-    # don't swap — that's the anti-thrashing guarantee.
     while candidates:
         cand = candidates[0]
         weakest = min(chosen, key=lambda c: ratios[c])
@@ -78,7 +81,7 @@ def select_target_names(
             chosen.append(cand)
             candidates.pop(0)
         else:
-            break  # df is sorted desc; nothing below will improve either
+            break
 
     return chosen
 
@@ -88,24 +91,48 @@ def compute_target_shares(
     prices: dict[str, float],
     total_nav: float,
     max_positions: int,
+    weighting: str = "equal",
+    ratios: dict[str, float] | None = None,
     lot_size: int = LOT_SIZE,
 ) -> dict[str, int]:
-    """Equal-weight sizing. NAV split evenly across max_positions slots
-    (so adding a name later doesn't dilute existing ones); shares per
-    name rounded down to lot_size.
+    """Compute target share counts per target name.
+
+    weighting:
+      'equal' — NAV split evenly across max_positions slots, so adding
+        a name later doesn't dilute existing ones (the un-allocated
+        slots' worth sits in cash).
+      'ratio' — weights proportional to (ratio_i / Σ ratios).
+        Requires `ratios` keyed by sec_code; concentrates capital in
+        the highest-conviction names. Total deployed capital ≈ NAV
+        regardless of how many names actually qualify.
+
+    All shares rounded down to lot_size.
     """
     if not target_names:
         return {}
-    slot_value = total_nav / max_positions
+
+    if weighting == "equal":
+        slot_value = total_nav / max_positions
+        slot_for: dict[str, float] = {n: slot_value for n in target_names}
+    elif weighting == "ratio":
+        if ratios is None:
+            raise ValueError("weighting='ratio' requires ratios dict")
+        weights = {n: max(ratios.get(n, 0), 0) for n in target_names}
+        total_w = sum(weights.values())
+        if total_w <= 0:
+            return {n: 0 for n in target_names}
+        slot_for = {n: total_nav * (w / total_w) for n, w in weights.items()}
+    else:
+        raise ValueError(f"unknown weighting: {weighting}")
+
     shares: dict[str, int] = {}
     for name in target_names:
         p = prices.get(name)
         if not p or p <= 0:
             shares[name] = 0
             continue
-        raw = int(slot_value // p)
-        rounded = (raw // lot_size) * lot_size
-        shares[name] = rounded
+        raw = int(slot_for[name] // p)
+        shares[name] = (raw // lot_size) * lot_size
     return shares
 
 

--- a/src/stock_screening/simulation/strategies.py
+++ b/src/stock_screening/simulation/strategies.py
@@ -1,0 +1,65 @@
+"""Strategy registry for the multi-strategy simulator.
+
+A Strategy bundles the daily portfolio-construction parameters that
+turn `t_screen_results` (qualifying names + ratios) into a target
+portfolio. All strategies share the same screen output — they only
+differ in selection / sizing / turnover rules — so equity curves are
+directly comparable across the same dates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Strategy:
+    name: str
+    max_positions: int
+    weighting: str  # 'equal' | 'ratio'
+    swap_rule: str  # 'strict_improvement' | 'full_rebalance'
+    initial_capital: int = 10_000_000
+    transaction_cost_bps: int = 10
+
+
+STRATEGIES: tuple[Strategy, ...] = (
+    # Baseline: top-20, equal-weight, anti-thrashing swap. Matches the
+    # original plan and the 1-week smoke result in the refactor PR.
+    Strategy(
+        name="netcash_top20_equal",
+        max_positions=20,
+        weighting="equal",
+        swap_rule="strict_improvement",
+    ),
+    # Concentration test: half the names, same rules. Higher idiosyncratic
+    # risk but better signal capture if the top of the screen is real.
+    Strategy(
+        name="netcash_top10_concentrated",
+        max_positions=10,
+        weighting="equal",
+        swap_rule="strict_improvement",
+    ),
+    # Turnover test: same N, same sizing, but no anti-thrashing rule —
+    # rebalance to whatever's top-20 today. Costs accumulate on noise.
+    Strategy(
+        name="netcash_top20_full_rebalance",
+        max_positions=20,
+        weighting="equal",
+        swap_rule="full_rebalance",
+    ),
+    # Conviction test: weight proportional to ratio. Names with higher
+    # net-cash get more capital. Same N and swap rule as baseline.
+    Strategy(
+        name="netcash_top20_ratio_weighted",
+        max_positions=20,
+        weighting="ratio",
+        swap_rule="strict_improvement",
+    ),
+)
+
+
+def by_name(name: str) -> Strategy:
+    for s in STRATEGIES:
+        if s.name == name:
+            return s
+    raise KeyError(f"unknown strategy: {name}")

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -40,4 +40,4 @@ def test_debt_components_match_concepts():
 def test_no_label_collisions():
     """Labels shouldn't map to multiple fields silently — that would
     produce non-deterministic mart projection."""
-    assert len(CONCEPT_BY_LABEL) >= len({l for l in CONCEPT_BY_LABEL.keys()})
+    assert len(CONCEPT_BY_LABEL) >= len({lbl for lbl in CONCEPT_BY_LABEL.keys()})

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,6 +3,8 @@ persist_screen_results) covered by the migration smoke test in phase 11."""
 
 from stock_screening.screening.metrics import (
     INVESTMENT_SECURITIES_HAIRCUT,
+    MOMENTUM_THRESHOLD,
+    OP_YIELD_THRESHOLD,
     QUALIFY_THRESHOLD,
 )
 
@@ -30,3 +32,14 @@ def test_formula_components_and_threshold_match_plan():
     ratio = (100 - 20 + INVESTMENT_SECURITIES_HAIRCUT * 10) / 87
     assert ratio == 1.0
     assert ratio >= QUALIFY_THRESHOLD
+
+
+def test_quality_filter_constants():
+    """Document the value-trap-filter thresholds. Tuned from the 2022
+    cohort 3-year analysis (cross_table_netcash_2022.py)."""
+    # Operating-income yield > 5% caught 3 of 5 worst traps at the
+    # cost of one turnaround winner.
+    assert OP_YIELD_THRESHOLD == 0.05
+    # Modest "market is starting to price it in" filter — also catches
+    # pieces of the trap pattern.
+    assert MOMENTUM_THRESHOLD == 0.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -21,10 +21,12 @@ def test_investment_securities_haircut_is_70_percent():
 
 
 def test_formula_components_and_threshold_match_plan():
-    """Sanity: ratio = (current_assets - interest_bearing_debt
+    """Sanity: ratio = (current_assets - total_liabilities
                       + 0.7*investment_securities) / market_cap.
-    A company with current_assets=100, debt=20, sec=10, mc=87 → ratio
-    = (100 - 20 + 7) / 87 = 1.0 → just qualifies."""
+    A company with current_assets=100, total_liabilities=20, sec=10, mc=87
+    → ratio = (100 - 20 + 7) / 87 = 1.0 → just qualifies. The choice
+    of total_liabilities vs interest_bearing_debt is justified in
+    metrics.py module docstring (empirical Q5-collapse fix)."""
     ratio = (100 - 20 + INVESTMENT_SECURITIES_HAIRCUT * 10) / 87
     assert ratio == 1.0
     assert ratio >= QUALIFY_THRESHOLD

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -3,7 +3,6 @@ import pytest
 
 from stock_screening.simulation.rebalance import (
     LOT_SIZE,
-    Trade,
     compute_target_shares,
     generate_trades,
     select_target_names,
@@ -161,3 +160,75 @@ def test_no_trade_when_price_missing():
 def test_lot_size_is_100():
     """JP standard board lot. Hardcoded constant; flag if it ever changes."""
     assert LOT_SIZE == 100
+
+
+# Multi-strategy: full_rebalance + ratio weighting --------------------
+
+
+def test_select_full_rebalance_ignores_holdings():
+    """full_rebalance: target = top N regardless of current holdings."""
+    qual = _qual([("A", 3.0), ("B", 2.5), ("C", 2.0)])
+    out = select_target_names(qual, current=["X", "Y"], max_positions=2, swap_rule="full_rebalance")
+    assert out == ["A", "B"]
+
+
+def test_full_rebalance_drops_held_when_better_exists():
+    qual = _qual([("X", 1.5), ("Y", 1.4), ("Z", 1.3)])
+    out = select_target_names(qual, current=["Z"], max_positions=2, swap_rule="full_rebalance")
+    assert out == ["X", "Y"]
+
+
+def test_select_unknown_swap_rule_raises():
+    with pytest.raises(ValueError, match="unknown swap_rule"):
+        select_target_names(_qual([("A", 2.0)]), current=[], max_positions=1, swap_rule="other")
+
+
+def test_ratio_weighting_concentrates_on_higher_ratio():
+    """Two names, ratios 3:1 → first should get ~3× the second's shares
+    (modulo lot rounding)."""
+    shares = compute_target_shares(
+        target_names=["HI", "LO"],
+        prices={"HI": 100.0, "LO": 100.0},
+        total_nav=1_000_000,
+        max_positions=2,
+        weighting="ratio",
+        ratios={"HI": 3.0, "LO": 1.0},
+    )
+    # HI gets 3/4 of NAV (750K @ 100 = 7500 shares), LO gets 1/4 (2500)
+    assert shares["HI"] == 7500
+    assert shares["LO"] == 2500
+
+
+def test_ratio_weighting_handles_zero_total():
+    """If all ratios are zero/negative, every name gets 0 shares."""
+    shares = compute_target_shares(
+        target_names=["A", "B"],
+        prices={"A": 100.0, "B": 100.0},
+        total_nav=1_000_000,
+        max_positions=2,
+        weighting="ratio",
+        ratios={"A": 0, "B": 0},
+    )
+    assert shares == {"A": 0, "B": 0}
+
+
+def test_ratio_weighting_requires_ratios():
+    with pytest.raises(ValueError, match="requires ratios"):
+        compute_target_shares(
+            target_names=["A"],
+            prices={"A": 100.0},
+            total_nav=1_000_000,
+            max_positions=1,
+            weighting="ratio",
+        )
+
+
+def test_unknown_weighting_raises():
+    with pytest.raises(ValueError, match="unknown weighting"):
+        compute_target_shares(
+            target_names=["A"],
+            prices={"A": 100.0},
+            total_nav=1_000_000,
+            max_positions=1,
+            weighting="other",
+        )

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,37 @@
+from stock_screening.simulation.strategies import STRATEGIES, by_name
+
+
+def test_strategy_names_are_unique():
+    names = [s.name for s in STRATEGIES]
+    assert len(names) == len(set(names))
+
+
+def test_baseline_is_registered():
+    s = by_name("netcash_top20_equal")
+    assert s.max_positions == 20
+    assert s.weighting == "equal"
+    assert s.swap_rule == "strict_improvement"
+
+
+def test_ratio_weighted_strategy_is_registered():
+    s = by_name("netcash_top20_ratio_weighted")
+    assert s.weighting == "ratio"
+
+
+def test_full_rebalance_strategy_is_registered():
+    s = by_name("netcash_top20_full_rebalance")
+    assert s.swap_rule == "full_rebalance"
+
+
+def test_concentrated_has_smaller_n():
+    s = by_name("netcash_top10_concentrated")
+    assert s.max_positions == 10
+
+
+def test_all_strategies_have_valid_swap_and_weighting():
+    """Every registered strategy must use values the rebalance code knows."""
+    valid_swap = {"strict_improvement", "full_rebalance"}
+    valid_weighting = {"equal", "ratio"}
+    for s in STRATEGIES:
+        assert s.swap_rule in valid_swap, f"{s.name}: bad swap_rule {s.swap_rule}"
+        assert s.weighting in valid_weighting, f"{s.name}: bad weighting {s.weighting}"


### PR DESCRIPTION
## Summary

Builds on the refactor PR (#3). Adds a multi-strategy paper-trading
framework, an op-income value-trap filter, a turnaround signal, and
the data infrastructure to backtest both — including a Prior1Year XBRL
re-parse that effectively doubles our visible fiscal-year history.

Headlines validated against real data:
- Net-cash formula switched to `total_liabilities`: Q5-collapse
  artifact disappears, monotonic ratio→return relationship holds
  through the top quintile.
- 12-month live backtest of the daily-rebalance strategy: −37% vs
  TOPIX, traced to high-turnover commission drag (12% of NAV) and
  the strict-improvement swap rule thrashing on noise.
- Buy-and-hold quintile analysis (no portfolio sim): top decile
  median +71%, mean +99.9% over 3 years vs TOPIX +82.4% — net-cash
  signal works, our daily-rebalance implementation eats the alpha.
- Value-trap filter: op_yield > 5% catches 3 of 5 worst traps in the
  2022 cohort at the cost of 1 turnaround winner.
- Turnaround signal (op_income_yoy>20% AND sales_yoy>0): kept as an
  additive signal, not a hard filter — equally good at catching
  winners and traps in our cohort.

## What changed

### Data infrastructure
- `--phase` flag on `backfill_window.py` (prices / financials /
  marketcap / all) — enables staged 12-month bootstrap and per-phase
  re-runs.
- 4-year price history (2022-04-25 → 2026-04-24) ingested.
- 3-year financials backfill (4 years total covering 2022-2025
  reports) — 17K securities reports, 4,181 distinct TSE companies in
  the mart.
- adj_close + adj_factor on `t_daily_stock_perf` (alembic 0008)
  — required for any backtest crossing a stock split. 1306 ETF split
  10:1 in winter 2025-26; without this fix the benchmark looked
  −86% in the first backtest.
- Prior1Year* XBRL contexts now extracted by the parser; mart
  generates two rows per filing (current FY + prior FY). Mart grew
  ~15.7K → ~19.4K rows; FY2020 and pre-window data now available
  for backtest YoY computations.

### Schema (alembic 0007–0010)
- 0007: `strategy_name` on sim tables (multi-strategy partitioning)
- 0008: `adj_close`, `adj_factor` on `t_daily_stock_perf`
- 0009: `operating_income` on `t_financials_annual`
- 0010: `net_sales` on `t_financials_annual`

### Code
- `simulation/strategies.py`: 4 registered strategies sharing one
  screen output (top20_equal, top10_concentrated,
  top20_full_rebalance, top20_ratio_weighted). All sim functions
  parameterized by strategy.
- `screening/metrics.py`:
  - Switched to `total_liabilities` formula
  - Added op_yield + 6m momentum filters to qualifies
  - New `compute_turnaround_score` for YoY op/sales/margin trends
- `financials/concepts.py`: added `operating_income`, `net_sales`,
  XBRL concept IDs and Japanese label fallbacks.
- `financials/build_annual_mart.py`: now writes both current-year
  and prior-year mart rows from a single filing.

### Scripts (analysis tools)
- `backtest_smallcap_netcash.py` — daily-rebalance backtest
- `cross_table_netcash_2022.py` — bucket-and-hold per-stock 3-year
  return analysis
- `list_3y_returns_smallcap_netcash.py` — emit per-stock 3-year list
- `reparse_for_prior_year.py` — reprocess existing filings to ingest
  Prior1Year* facts (idempotent via t_financials PK)

### Docs
- `docs/analysis_notes.md` — running log of empirical findings:
  formula choice, filter rationale, turnaround signal limitations,
  look-ahead caveat in production screen, concept-coverage gaps for
  the financial sector.

## Test plan

- [x] `uv run pytest` (38 tests passing, includes new strategy +
      filter constants tests)
- [x] `uv run ruff check src/ tests/ scripts/ airflow/dags/`
- [x] alembic 0007-0010 applied cleanly
- [x] 4-year price backfill + adj_close/marketCap recompute
      end-to-end
- [x] 4-year financials backfill (4-way parallel) + Prior1Year*
      reparse (4-way parallel)
- [x] Multi-strategy 1-week backfill end-to-end
- [x] 3-year buy-and-hold + 3-year daily-rebalance backtests
- [x] Live screen on 2026-04-24: 95 stocks pass all 3 filters
      (net-cash, op_yield, momentum); 55 separately tagged as
      turnaround candidates

## Known follow-ups

1. **Look-ahead bias in production screen** — `_SCREEN_SQL` filters
   `period_end <= run_date` rather than `submitDateTime <= run_date`.
   Fine for live trading; backtest scripts use the corrected version.
   A future change should fix the production query so backtests
   running through the standard pipeline are honest by default.
2. **Financial-sector concepts** — banks/brokers/insurance use
   `営業収益`, `経常収益`, etc. instead of `売上高`. Currently they
   show NULL net_sales and undefined sales_yoy. Easy add but
   deferred.
3. **5-year history via Prior2Year, Prior3Year, Prior4Year** — same
   pattern as Prior1Year. Would unlock 5-year trend signals (e.g.
   3-year op income CAGR, sales stability).
4. **Strategy parameter tuning** — daily rebalance burned 12% on
   commissions. Test monthly / quarterly rebalance variants of each
   registered strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)