### PR TITLE
Add screen summary doc (backtest results + current candidates)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,14 @@ EDINET_KEY=
 # this project relies on.
 JQUANTS_API_KEY=
 
+# IBKR Flex Web Service — read-only positions sync. See
+# scripts/sync_ibkr_positions.py header for portal setup steps.
+# Generate token at: Performance & Reports → Flex Queries → Flex Web
+# Service. Create a Flex Query (Activity type, Open Positions section)
+# and paste its Query ID here. Token expires every ~6 months.
+IBKR_FLEX_TOKEN=
+IBKR_POSITIONS_QUERY_ID=
+
 # --- Postgres (financial_data DB) ---
 POSTGRES_USER=root
 POSTGRES_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ parameters.json
 /financial_data_pg16/
 # airflow logs (kept out of git, mounted into container)
 /airflow/logs/
+.DS_Store

--- a/docs/screen_summary.md
+++ b/docs/screen_summary.md
@@ -177,6 +177,61 @@ finding "value_momentum hurt returns." Across 4 entry dates,
 value_momentum (+9.2pp) beats baseline (+6.1pp) on average. The 2022
 finding was the noisy one, not the signal.
 
+## Low-float hybrid (validated edge, recommended overlay)
+
+**Setup**: within the sweet-spot screen (¥3-30B + ratio>1.5 + PER≤10),
+take the bottom 33% by issued shares. Over 10 quarterly entry dates
+(2022-12 → 2025-03) with 12-month buy-and-hold, this beats TOPIX by
+**+24.5pp on average** (n=3.4 stocks per window, 80% win rate).
+
+| Threshold | n/win | Avg return | Avg excess | MC p-value | Note |
+|---|---|---|---|---|---|
+| 25% | 2.4 | +49.1% | +29.4pp | 0.014 | Highest excess but single-stock risk |
+| **33%** | **3.4** | **+44.2%** | **+24.5pp** | **0.006** | Recommended |
+| 50% | 5.8 | +35.8% | +16.1pp | 0.226 | Edge is sweet-spot effect, not float |
+| 100% (no float) | 13.4 | +33.3% | +13.6pp | — | Sweet-spot baseline |
+
+The Monte Carlo column (p-value vs 500 random subsets per entry of
+the same size within sweet-spot) is the key validation: **at the 50%
+threshold the float signal is indistinguishable from random selection
+within the sweet-spot.** Only at 25-33% does float add measurable
+value beyond the sweet-spot effect itself.
+
+**Why low float?** Empirically, low share count (proxy for tightly-held
+ownership / illiquidity premium) within an already-cheap, net-cash-rich
+universe selects for stocks where the value is more likely to be
+realized via buyout, special dividend, or accumulation by long-horizon
+holders rather than diluted away.
+
+Sanity checks that ruled out alternative explanations:
+- **Not "smaller stocks":** Selecting bottom 33% by market cap instead
+  of issued shares gave only +6.3pp excess (vs +24.5pp for float).
+- **Not single-stock dependence:** 34 total picks across 10 entries
+  span 15 unique stocks. Removing the most-recurring stock still
+  leaves +17.7pp excess.
+- **Not just survival bias:** Per-pick distribution across all 34
+  picks is nearly symmetric (skew 0.09), median +46%, P10 −1.6% —
+  the edge is broad-based, not driven by outliers.
+
+### Current picks at 33% threshold (n=7, 2026-04-26)
+
+7 stocks chosen from today's 24-stock sweet-spot universe by lowest
+issued shares:
+
+| Code | Company | Ratio | PER | MC ¥B | Shares (M) | Existing flag |
+|---|---|---|---|---|---|---|
+| 46350 | 東京インキ | 3.31 | 3.0 | 3.6 | 2.73 | T |
+| 56030 | 虹技 | 1.53 | 5.8 | 4.6 | 3.36 | **Q+T** |
+| 80460 | 丸藤シートパイル | 5.56 | 2.4 | 3.7 | 4.00 | Q |
+| 61370 | 小池酸素工業 | 2.42 | 2.3 | 8.4 | 4.52 | **Q+T** |
+| 80060 | ユアサ・フナショク | 2.08 | 3.9 | 8.0 | 4.90 | T |
+| 74270 | エコートレーディング | 1.84 | 5.4 | 5.4 | 6.08 | — |
+| 37980 | ULSグループ | 2.85 | 2.0 | 3.3 | 6.23 | T |
+
+5 of 7 already carry quality (Q) or turnaround (T) flags from the
+fundamental screen — the float signal is correlated with but not
+redundant to those signals.
+
 ## Caveats
 
 1. **Look-ahead bias**: production `compute_screen` filters by

--- a/docs/screen_summary.md
+++ b/docs/screen_summary.md
@@ -1,0 +1,186 @@
+# Screen summary — backtest results + current candidates
+
+*As of 2026-04-24. Snapshot in time; re-run the screen DAG for fresh data.*
+
+## Screening criteria (live)
+
+| Filter | Threshold |
+|---|---|
+| Market cap | ¥3B – ¥50B |
+| Net-cash ratio | > 1.5 |
+| PER (market_cap / net_income) | > 0 and ≤ 10 |
+
+Net-cash ratio is the conservative form:
+
+```
+ratio = (current_assets − total_liabilities + 0.7 × investment_securities) / market_cap
+```
+
+Choice rationale, formula history, and limitations are tracked in
+[`analysis_notes.md`](analysis_notes.md).
+
+## 3-year backtest results (entry 2022-12-30, exit on ratio<1 OR 2025-12-30)
+
+| Configuration | n | Mean Return | Median | vs TOPIX (+82.4%) |
+|---|---|---|---|---|
+| Old: ¥15-50B + ratio>1.5 (no PER) | 17 | +69.5% | +65.1% | −16pp |
+| Wider: ¥3-50B + ratio≥1.0 + PER≤10 | 105 | +41.6% | +31.6% | −50pp |
+| **Sweet spot: ¥3-50B + ratio>1.5 + PER≤10** | **34** | **+76.6%** | **+77.2%** | **−4pp** |
+
+The sweet spot configuration is what's used for "current candidates"
+below — it materially closed the gap to TOPIX while keeping
+diversification (n=34 vs the original n=17).
+
+### Why the wider universe helps
+
+Lowering the cap floor from ¥15B to ¥3B unlocked **6 of the top 12
+winners** (each returned ≥100% over 3 years) that the old criteria
+excluded:
+
+| Code | Company | Entry MC | Entry Ratio | 3y Return |
+|---|---|---|---|---|
+| 52800 | ヨシコン | ¥8.4B | 1.78 | **+177%** |
+| 81520 | ソマール | ¥3.5B | 2.58 | **+176%** |
+| 69730 | 協栄産業 | ¥5.2B | 1.65 | +144% |
+| 75230 | アールビバン | ¥5.4B | 2.07 | +138% |
+| 53630 | 東京窯業 | ¥12.0B | 1.86 | +123% |
+| 39540 | 昭和パックス | ¥6.7B | 1.73 | +115% |
+
+Top 12 overall (entries on 2022-12-30, ¥3-50B + ratio>1.5 + PER≤10):
+
+| Code | Company | Ratio | PER | MC ¥B | Return |
+|---|---|---|---|---|---|
+| 52800 | ヨシコン | 1.78 | 5.1 | 8.4 | +177% |
+| 81520 | ソマール | 2.58 | 5.1 | 3.5 | +176% |
+| 69730 | 協栄産業 | 1.65 | 2.5 | 5.2 | +144% |
+| 87060 | 極東証券 | 2.02 | 8.9 | 18.8 | +142% |
+| 75230 | アールビバン | 2.07 | 4.7 | 5.4 | +138% |
+| 53630 | 東京窯業 | 1.86 | 6.9 | 12.0 | +123% |
+| 39540 | 昭和パックス | 1.73 | 6.1 | 6.7 | +115% |
+| 80840 | 菱電商事 | 1.66 | 7.3 | 36.6 | +113% |
+| 42340 | サンエー化研 | 1.91 | 3.3 | 5.1 | +106% |
+| 42310 | タイガースポリマー | 2.02 | 9.7 | 8.1 | +105% |
+| 59830 | イワブチ | 2.04 | 6.5 | 4.9 | +101% |
+| 18790 | 新日本建設 | 1.73 | 4.2 | 45.7 | +100% |
+
+Why ratio > 1.5 (not 1.0) is the right threshold despite the Shikiho
+article using 1.0: our quintile analysis (see [`analysis_notes.md`
+section 1](analysis_notes.md)) shows the 1.0–1.5 cohort returned only
++22% mean over 3 years, vs +60-70% for ratio > 1.5. Including 1.0–1.5
+dilutes the universe with low-conviction names.
+
+## Current candidates (2026-04-24)
+
+29 stocks meet all three filters. **Flags**: `Q` = quality
+(op_yield > 5% AND 6m_mom > 0%); `T` = turnaround
+(op_income_yoy > 20% AND sales_yoy > 0).
+
+### 🏆 Highest conviction — passes both Q and T
+
+| Code | Company | Ratio | PER | MC ¥B | Op Yield | 6m Mom | Op YoY | Sales YoY |
+|---|---|---|---|---|---|---|---|---|
+| **41160** | 大日精化工業 | 2.96 | 1.9 | 19.2 | 36.4% | +10.9% | +54% | +4.1% |
+| **61370** | 小池酸素工業 | 2.42 | 2.3 | 8.4 | 65.2% | +25.6% | +26% | +7.4% |
+| **56030** | 虹技 | 1.53 | 5.8 | 4.6 | 24.2% | +8.1% | +42% | +1.4% |
+
+### 💎 Quality (Q) only — already-strong businesses with positive momentum
+
+| Code | Company | Ratio | PER | MC ¥B | Op Yield | 6m Mom |
+|---|---|---|---|---|---|---|
+| 80460 | 丸藤シートパイル | 5.56 | 2.4 | 3.7 | 42.4% | +26.8% |
+| 21460 | UTグループ | 3.32 | 0.8 | 7.3 | 110.7% | +2.8% |
+| 54510 | ヨドコウ | 3.26 | 3.2 | 42.8 | 32.5% | +7.0% |
+| 40080 | 住友精化 | 2.02 | 2.8 | 16.7 | 64.0% | +12.7% |
+| 67970 | 名古屋電機工業 | 1.89 | 3.5 | 7.8 | 35.2% | +1.5% |
+| 26120 | かどや製油 | 1.60 | 6.3 | 14.7 | 21.5% | +22.1% |
+| 18470 | イチケン | 1.54 | 4.2 | 19.7 | 34.9% | +25.9% |
+| 15180 | 三井松島HD | 1.52 | 2.0 | 17.5 | 43.5% | +3.0% |
+| 82190 | 青山商事 | 1.52 | 4.2 | 39.7 | 31.7% | +0.1% |
+
+### 🔄 Turnaround (T) only — operating recovery + revenue growth
+
+| Code | Company | Ratio | PER | MC ¥B | Op YoY | Sales YoY | Note |
+|---|---|---|---|---|---|---|---|
+| 49140 | 高砂香料工業 | 2.41 | 1.7 | 23.0 | **+562%** | +17.0% | Massive recovery; mom −28% (price hasn't caught up yet) |
+| 80570 | 内田洋行 | 2.00 | 2.1 | 20.5 | +30% | +21.3% | Both top and bottom recovering |
+| 46350 | 東京インキ | 3.31 | 3.0 | 3.6 | +70% | +6.6% | |
+| 37980 | ULSグループ | 2.85 | 2.0 | 3.3 | +49% | +27.2% | |
+| 80060 | ユアサ・フナショク | 2.08 | 3.9 | 8.0 | +47% | +2.9% | |
+
+### Other passing names (no Q/T flag)
+
+These pass net-cash + cap + PER but don't pass our quality OR
+turnaround signals — closer to "raw value plays" without an
+identified catalyst. Some of these are chronic value traps from the
+2022 study (双葉電子工業 was on the original list and returned only
++10% over 3 years).
+
+| Code | Company | Ratio | PER | MC ¥B | Notes |
+|---|---|---|---|---|---|
+| 54640 | モリ工業 | 4.62 | 1.8 | 7.3 | op_yld 74% but mom −6%, sales declining |
+| 18220 | 大豊建設 | 3.82 | 3.6 | 13.5 | Sales −12%; op spike likely cyclical |
+| 80750 | 神鋼商事 | 3.29 | 2.4 | 20.2 | mom slightly negative |
+| 18660 | 北野建設 | 2.81 | 2.2 | 7.4 | op declining |
+| 56020 | 栗本鐵工所 | 2.28 | 2.8 | 19.4 | mom −9% |
+| 76280 | オーハシテクニカ | 2.06 | 9.7 | 14.8 | op_yld only 12% |
+| 80430 | スターゼン | 1.96 | 1.8 | 22.2 | flat fundamentals |
+| 27880 | アップルインターナショナル | 1.96 | 6.0 | 4.7 | op_yoy −59% |
+| 64630 | TPR | 1.92 | 4.8 | 42.3 | op slightly declining |
+| 74270 | エコートレーディング | 1.84 | 5.4 | 5.4 | op_yoy −21% |
+| 52730 | 三谷セキサン | 1.66 | 3.6 | 36.4 | mom −4% |
+| 75950 | アルゴグラフィックス | 1.59 | 4.2 | 31.3 | mom flat |
+
+## Caveats
+
+1. **Look-ahead bias**: production `compute_screen` filters by
+   `period_end <= run_date`, not `submitDateTime <= run_date`. For
+   live screening this is fine (filings are knowable when submitted).
+   Backtest scripts use the corrected version.
+
+2. **IFRS reporters mis-screened**: companies on IFRS accounting
+   (some industrials, including 5202 日本板硝子) get garbage values
+   because our `concepts.py` only covers JGAAP namespace. Affects a
+   small but non-zero subset of names. Fix would be to add IFRS
+   concept IDs (`jpigp_cor:*`).
+
+3. **Financial-sector concepts**: brokers/banks/insurance use
+   `営業収益` instead of `売上高`, so `sales_yoy` is undefined for
+   them. They still pass net-cash + PER filters but the turnaround
+   signal can't be computed.
+
+4. **Single-period backtest**: results are entry-2022-12-30 only.
+   Different entry dates would give different numbers. The 2023-2026
+   window was a strong Japan bull market; cohort returns reflect that.
+
+5. **Survivorship bias**: stocks that delisted between 2022-12-30 and
+   2025-12-30 are not in our DB. Their bad outcomes aren't reflected;
+   actual realized returns of someone trying to reproduce this would
+   be slightly lower.
+
+## Reproducing
+
+```bash
+# Live screen (today's universe)
+PYTHONPATH=src uv run python -c "
+from datetime import date
+from stock_screening import db
+from stock_screening.screening.metrics import compute_screen
+df = compute_screen(db.get_engine(), date.today())
+qualifying = df[(df['market_cap'].between(3e9, 50e9)) & (df['ratio'] > 1.5)]
+print(qualifying.sort_values('ratio', ascending=False))
+"
+
+# Re-run backtest
+PYTHONUNBUFFERED=1 uv run python scripts/backtest_shikiho_style_2022.py
+# Edit ENTRY_RATIO_MIN constant in the script to test different cutoffs
+```
+
+The `t_screen_results` table accumulates daily snapshots; rank changes
+over time can be tracked via SQL:
+
+```sql
+SELECT run_date, "secCode", ratio, qualifies
+FROM t_screen_results
+WHERE "secCode" = '41160'  -- 大日精化工業
+ORDER BY run_date DESC LIMIT 30;
+```

--- a/docs/screen_summary.md
+++ b/docs/screen_summary.md
@@ -130,6 +130,53 @@ identified catalyst. Some of these are chronic value traps from the
 | 52730 | 三谷セキサン | 1.66 | 3.6 | 36.4 | mom −4% |
 | 75950 | アルゴグラフィックス | 1.59 | 4.2 | 31.3 | mom flat |
 
+## Multi-entry robustness (2-year hold across 4 windows)
+
+The single-period sweet-spot result (+76.6%) raised the obvious "is
+this a 2022 cohort fluke?" question. The robustness lab
+(`scripts/strategy_lab_robustness.py`) re-runs all strategies on 4
+entry dates spaced ~6mo apart with a fixed 2-year hold, comparing
+each to TOPIX over the same window.
+
+| Strategy | Avg return | Avg excess vs TOPIX | Win rate | Avg n |
+|---|---|---|---|---|
+| **value_quality** (op_margin>10%) | +64.8% | **+25.2pp** | 100% | 1.7 |
+| **sales_growth** (sales_yoy>5%) | +57.8% | **+19.9pp** | 100% | 7.5 |
+| **z_composite** (top 20% blend) | +49.4% | +11.5pp | 100% | 9.5 |
+| **top10_by_ratio** (concentrated) | +48.7% | +10.9pp | 100% | 9.5 |
+| **value_momentum** (mom_6m>0) | +47.0% | +9.2pp | 75% | 11.5 |
+| baseline_sweet_spot | +43.9% | +6.1pp | 100% | 20.0 |
+| low_per_top10 | +29.6% | −8.2pp | 25% | 7.2 |
+| cash_compounders | +25.6% | −12.2pp | 25% | 43.2 |
+| reversal | +15.0% | −19.1pp | 0% | 2.3 |
+| qmom (high op_yld + momentum) | +4.3% | **−33.5pp** | 0% | 158.0 |
+
+Avg TOPIX across the 4 entries (2022-12-30, 2023-06-30, 2023-12-29,
+2024-06-28): +37.9%.
+
+**Key takeaways**:
+
+- **The value-net-cash core works across all 4 windows.** Baseline
+  sweet-spot beat TOPIX 4-for-4 by an average +6pp. Not a 2022 fluke.
+- **`sales_growth` is the best usable signal.** +19.9pp excess with
+  n=7.5 average — enough diversification, real edge. Adding "top-line
+  accelerating" to net-cash value reliably finds compounders.
+- **`top10_by_ratio` is robust as a concentrated bet.** +10.9pp excess
+  with 100% win rate. The original +87.7% (3-yr hold) wasn't a fluke,
+  just amplified by the longer horizon.
+- **`value_quality` has the highest excess but n=1.7** — not a usable
+  strategy, just a tiny set of stocks that happen to win.
+- **`qmom` is consistently disastrous (−33.5pp).** High op_yield + high
+  6m momentum picks late-cycle peak earners. Strong negative confirmation
+  that "buy what's working" without value discipline destroys returns.
+- **`cash_compounders` is too inclusive.** Big universe (n=43), mediocre
+  picks. The composite filter dilutes too aggressively.
+
+This is also the empirical answer to the surprising single-period
+finding "value_momentum hurt returns." Across 4 entry dates,
+value_momentum (+9.2pp) beats baseline (+6.1pp) on average. The 2022
+finding was the noisy one, not the signal.
+
 ## Caveats
 
 1. **Look-ahead bias**: production `compute_screen` filters by

--- a/scripts/generate_trade_plan.py
+++ b/scripts/generate_trade_plan.py
@@ -1,0 +1,321 @@
+"""Generate a manual-execution trade plan from current IBKR positions
++ today's screen + excess cash.
+
+Output: classified status of each existing position (HOLD / WATCH /
+EXIT / NO_DATA), a recommended deployment of excess cash into the
+best-fit target pick, and the full target portfolio for reference.
+
+You run this quarterly (or whenever you have new cash). It tells you
+exactly which orders to place; you submit them manually in IBKR.
+
+Usage:
+    set -a && . ./.env && set +a && PYTHONPATH=src \\
+      uv run python scripts/generate_trade_plan.py \\
+      --excess-usd 889 [--fx 150] [--target-n 7]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+from stock_screening.ibkr.flex_client import FlexClient
+from stock_screening.ibkr.positions import enrich_with_screen, parse_open_positions
+
+LOT = 100  # Japanese stock minimum trading unit
+HAIRCUT = 0.7
+EXIT_RATIO = 1.0
+ENTRY_RATIO = 1.5
+LIMIT_BUFFER_PCT = 0.005  # buy 0.5% above last close
+
+
+def build_target_picks(engine, today: date, n: int = 7) -> pd.DataFrame:
+    """Today's top picks per the validated strategy: lowest-float 33%
+    within sweet-spot 3-30B + ratio>1.5 + PER<=10. Returned in float-rank
+    order; n controls cutoff (defaults to ~33%)."""
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities, fa.operating_income,
+                           fa.net_sales, fa.net_income, fa.issued_shares,
+                           fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :today
+                      AND fa.current_assets IS NOT NULL
+                ),
+                latest AS (SELECT DISTINCT ON (sec_code) * FROM visible
+                           ORDER BY sec_code, period_end DESC),
+                ranked AS (
+                    SELECT fa2."secCode", fa2.period_end, fa2.operating_income,
+                           fa2.net_sales,
+                           LAG(fa2.operating_income) OVER w op_prev,
+                           LAG(fa2.net_sales)        OVER w sales_prev
+                    FROM t_financials_annual fa2
+                    JOIN t_doc_list dl2 ON dl2."docID" = fa2.source_doc_id
+                    WHERE dl2."submitDateTime"::date <= :today
+                    WINDOW w AS (PARTITION BY fa2."secCode" ORDER BY fa2.period_end)
+                ),
+                yoy AS (
+                    SELECT DISTINCT ON ("secCode") "secCode" sec_code, op_prev, sales_prev
+                    FROM ranked WHERE op_prev IS NOT NULL OR sales_prev IS NOT NULL
+                    ORDER BY "secCode", period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.operating_income, l.net_sales,
+                       l.net_income, l.issued_shares,
+                       y.op_prev, y.sales_prev,
+                       d_now.adj_close price_now, d_now."marketCap" mc,
+                       d_6mo.adj_close p_6mo,
+                       (SELECT "filerName" FROM t_doc_list
+                        WHERE "secCode"=l.sec_code ORDER BY "submitDateTime" DESC LIMIT 1) name
+                FROM latest l
+                JOIN LATERAL (SELECT adj_close, "marketCap" FROM t_daily_stock_perf p
+                              WHERE p."ShokenCode"=l.sec_code AND p."Date" <= :today
+                                AND adj_close IS NOT NULL AND "marketCap" IS NOT NULL
+                              ORDER BY "Date" DESC LIMIT 1) d_now ON TRUE
+                LEFT JOIN LATERAL (SELECT adj_close FROM t_daily_stock_perf p
+                                   WHERE p."ShokenCode"=l.sec_code
+                                     AND p."Date" BETWEEN :s6_s AND :s6_e
+                                     AND adj_close IS NOT NULL
+                                   ORDER BY "Date" DESC LIMIT 1) d_6mo ON TRUE
+                LEFT JOIN yoy y ON y.sec_code = l.sec_code
+                """
+            ),
+            {"today": today,
+             "s6_s": today - timedelta(days=200),
+             "s6_e": today - timedelta(days=160)},
+        ).fetchall()
+
+    cols = ["sec_code", "current_assets", "total_liabilities", "investment_securities",
+            "operating_income", "net_sales", "net_income", "issued_shares",
+            "op_prev", "sales_prev", "price_now", "mc", "p_6mo", "name"]
+    df = pd.DataFrame(rows, columns=cols)
+    for c in [c for c in cols if c not in ("sec_code", "name")]:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+
+    df["ratio"] = (
+        df["current_assets"] - df["total_liabilities"]
+        + HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["mc"]
+    df["per"] = df["mc"] / df["net_income"]
+    df["op_yield"] = df["operating_income"] / df["mc"]
+    df["op_yoy"] = (df["operating_income"] - df["op_prev"]) / df["op_prev"].abs()
+    df["sales_yoy"] = (df["net_sales"] - df["sales_prev"]) / df["sales_prev"]
+    df["mom_6m"] = df["price_now"] / df["p_6mo"] - 1
+    df["q_flag"] = (df["op_yield"] > 0.05) & (df["mom_6m"] > 0)
+    df["t_flag"] = (df["op_yoy"] > 0.20) & (df["sales_yoy"] > 0)
+
+    sweet = df[
+        (df["mc"] >= 3e9) & (df["mc"] <= 30e9)
+        & (df["ratio"] > ENTRY_RATIO)
+        & (df["per"] > 0) & (df["per"] <= 10)
+    ].dropna(subset=["issued_shares"]).copy()
+    sweet = sweet.sort_values("issued_shares").reset_index(drop=True)
+    return sweet.head(n)
+
+
+def limit_price(last_close: float) -> int:
+    """Round limit price to a sensible tick. JPX tick rules vary by price;
+    for most small caps in our screen, ¥1 ticks below ¥3000 are fine."""
+    raw = last_close * (1 + LIMIT_BUFFER_PCT)
+    return int(round(raw))
+
+
+def best_deployment(excess_jpy: float, target_picks: pd.DataFrame,
+                    current_codes: set[str]) -> dict | None:
+    """Among target picks not already held, find the highest-conviction
+    one whose 100-share lot fits the budget. Tiebreak: highest ratio."""
+    candidates = target_picks[~target_picks["sec_code"].isin(current_codes)].copy()
+    if candidates.empty:
+        return None
+    candidates["lot_cost"] = candidates["price_now"] * LOT
+    affordable = candidates[candidates["lot_cost"] <= excess_jpy].copy()
+    if affordable.empty:
+        return None
+    # Score: prefer higher ratio (margin of safety) then Q+T flag count
+    affordable["flag_count"] = affordable["q_flag"].astype(int) + affordable["t_flag"].astype(int)
+    affordable = affordable.sort_values(
+        ["flag_count", "ratio"], ascending=[False, False]
+    ).reset_index(drop=True)
+    pick = affordable.iloc[0]
+    return {
+        "sec_code": pick["sec_code"],
+        "name": pick["name"],
+        "shares": LOT,
+        "limit": limit_price(float(pick["price_now"])),
+        "cost": LOT * limit_price(float(pick["price_now"])),
+        "last_close": float(pick["price_now"]),
+        "ratio": float(pick["ratio"]),
+        "per": float(pick["per"]),
+        "flags": (("Q" if pick["q_flag"] else "")
+                  + ("T" if pick["t_flag"] else "")) or "—",
+    }
+
+
+def fetch_positions(token: str, query_id: str) -> pd.DataFrame:
+    client = FlexClient(token)
+    resp = client.fetch_query(query_id)
+    positions = parse_open_positions(resp.root)
+    if not positions:
+        return pd.DataFrame()
+    engine = db.get_engine()
+    return enrich_with_screen(engine, positions)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--excess-usd", type=float, default=0,
+                   help="Excess cash in USD; converted to JPY at --fx")
+    p.add_argument("--excess-jpy", type=float, default=0,
+                   help="Excess cash in JPY (alternative to --excess-usd)")
+    p.add_argument("--fx", type=float, default=150.0,
+                   help="USD/JPY rate for conversion (default 150)")
+    p.add_argument("--target-n", type=int, default=7,
+                   help="Number of target picks (default 7 = lowest-float 33%%)")
+    args = p.parse_args()
+
+    if args.excess_jpy:
+        excess_jpy = args.excess_jpy
+        excess_label = f"¥{excess_jpy:,.0f}"
+    elif args.excess_usd:
+        excess_jpy = args.excess_usd * args.fx
+        excess_label = f"${args.excess_usd:.0f} × {args.fx} = ¥{excess_jpy:,.0f}"
+    else:
+        excess_jpy = 0
+        excess_label = "(none)"
+
+    token = os.environ.get("IBKR_FLEX_TOKEN")
+    query_id = os.environ.get("IBKR_POSITIONS_QUERY_ID")
+    if not token or not query_id:
+        print("ERROR: IBKR_FLEX_TOKEN and IBKR_POSITIONS_QUERY_ID must be set",
+              file=sys.stderr)
+        return 2
+
+    today = date.today()
+    engine = db.get_engine()
+
+    print(f"Generating trade plan for {today}...")
+    print(f"  Excess cash: {excess_label}")
+    print()
+    print("Fetching positions from IBKR...")
+    positions = fetch_positions(token, query_id)
+    print(f"  {len(positions)} open positions")
+    print(f"Building today's target portfolio (n={args.target_n})...")
+    targets = build_target_picks(engine, today, n=args.target_n)
+    print(f"  {len(targets)} target picks")
+
+    current_codes = set(positions["sec_code"]) if not positions.empty else set()
+    target_codes = set(targets["sec_code"])
+
+    # === EXIT TRIGGERS ===
+    print()
+    print("=" * 100)
+    print("EXIT TRIGGERS (ratio < 1.0 — strategy says sell)")
+    print("=" * 100)
+    if positions.empty:
+        print("  (no positions)")
+    else:
+        exits = positions[positions["ratio"] < EXIT_RATIO]
+        if exits.empty:
+            print("  None. All current positions still above the exit line.")
+        else:
+            for _, r in exits.iterrows():
+                print(f"  SELL {int(r['quantity']):>4} sh of {r['symbol']:<7} {r['description']}")
+                print(f"       ratio={r['ratio']:.2f}  current value ¥{r['mark_price']*r['quantity']:,.0f}")
+
+    # === EXISTING POSITION STATUS ===
+    print()
+    print("=" * 100)
+    print("EXISTING POSITIONS — action per holding")
+    print("=" * 100)
+    if positions.empty:
+        print("  (none)")
+    else:
+        for _, r in positions.iterrows():
+            in_target = r["sec_code"] in target_codes
+            ratio = r.get("ratio")
+            if pd.isna(ratio):
+                action = "MANUAL REVIEW (not in screen DB)"
+            elif ratio < EXIT_RATIO:
+                action = f"SELL ALL — ratio {ratio:.2f} below exit line"
+            elif ratio < ENTRY_RATIO:
+                action = f"HOLD — graduated to ratio {ratio:.2f} (1.0-1.5); do not add"
+            elif in_target:
+                action = f"HOLD — still in target portfolio (ratio {ratio:.2f})"
+            else:
+                action = f"HOLD — passes screen but not top-{args.target_n} (ratio {ratio:.2f})"
+            print(f"  {r['symbol']:<7} {(r['description'] or '')[:30]:<30}  {action}")
+
+    # === EXCESS CASH DEPLOYMENT ===
+    print()
+    print("=" * 100)
+    print("EXCESS CASH DEPLOYMENT")
+    print("=" * 100)
+    if excess_jpy <= 0:
+        print("  (no excess cash to deploy — pass --excess-usd or --excess-jpy)")
+    else:
+        plan = best_deployment(excess_jpy, targets, current_codes)
+        if plan is None:
+            print(f"  Budget ¥{excess_jpy:,.0f} insufficient for any target pick's lot, OR")
+            print("  all target picks already held. Consider topping up underweight position.")
+        else:
+            leftover = excess_jpy - plan["cost"]
+            print(f"  RECOMMENDED BUY:")
+            print()
+            print(f"    {plan['shares']} shares of {plan['sec_code']} {plan['name']}")
+            print(f"    Limit price: ¥{plan['limit']:,}  (last close ¥{plan['last_close']:.0f} + {LIMIT_BUFFER_PCT*100:.1f}% buffer)")
+            print(f"    Estimated cost: ¥{plan['cost']:,.0f}")
+            print(f"    Leftover cash: ¥{leftover:,.0f}")
+            print()
+            print(f"    Screen state: ratio {plan['ratio']:.2f}, PER {plan['per']:.1f}, flags {plan['flags']}")
+            print()
+            print(f"  Order to place in IBKR:")
+            print(f"    BUY {plan['shares']} {plan['sec_code']}  TYPE: LIMIT  PRICE: ¥{plan['limit']:,}  TIF: DAY")
+
+    # === FULL TARGET PORTFOLIO ===
+    print()
+    print("=" * 100)
+    print(f"FULL TARGET PORTFOLIO (top {args.target_n} hybrid picks today)")
+    print("=" * 100)
+    print(f"  {'code':<6} {'name':<28} {'ratio':>5} {'PER':>5} {'MC¥B':>5} "
+          f"{'shares M':>9} {'price':>7} {'flags':>6}  status")
+    for _, r in targets.iterrows():
+        flags = (("Q" if r["q_flag"] else "") + ("T" if r["t_flag"] else "")) or "—"
+        owned = "OWNED" if r["sec_code"] in current_codes else ""
+        print(f"  {r['sec_code']:<6} {(r['name'] or '')[:28]:<28} "
+              f"{r['ratio']:>5.2f} {r['per']:>5.1f} {r['mc']/1e9:>5.1f} "
+              f"{r['issued_shares']/1e6:>9.2f} ¥{r['price_now']:>6.0f} {flags:>6}  {owned}")
+
+    # === COVERAGE NOTES ===
+    print()
+    print("=" * 100)
+    print("COVERAGE NOTES")
+    print("=" * 100)
+    held_in_target = current_codes & target_codes
+    target_not_held = target_codes - current_codes
+    held_not_in_target = current_codes - target_codes
+    print(f"  Target picks held:        {len(held_in_target)}/{len(target_codes)}  "
+          f"({sorted(held_in_target) if held_in_target else 'none'})")
+    print(f"  Target picks NOT held:    {len(target_not_held)}  "
+          f"({sorted(target_not_held) if target_not_held else 'none'})")
+    print(f"  Held but not in target:   {len(held_not_in_target)}  "
+          f"({sorted(held_not_in_target) if held_not_in_target else 'none'})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hybrid_attribution.py
+++ b/scripts/hybrid_attribution.py
@@ -1,0 +1,357 @@
+"""Attribution check on the low_float_with_value hybrid edge.
+
+The sweep showed +29pp excess at 25% float threshold within sweet-spot.
+But is the edge actually FROM the float signal, or could it be:
+  (a) selection bias from smaller n,
+  (b) "smaller stocks" effect (low-float correlates with smaller cap),
+  (c) one stock (ソマール) appearing in many windows by coincidence?
+
+This script controls for each:
+  1. random_pct_X — random subset of size matching float_pct cohort
+  2. lowest_mc_X — same subset size but selected by smallest mc within sweet
+  3. lowest_float_X — the actual hybrid
+  4. top10_ratio   — concentrated value baseline
+  5. baseline_sweet — full sweet-spot
+
+Plus: per-pick distribution dump showing how often individual stocks
+recur, to test single-stock dependence.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+
+ENTRIES = [
+    date(2022, 12, 30), date(2023, 3, 31), date(2023, 6, 30), date(2023, 9, 29),
+    date(2023, 12, 29), date(2024, 3, 29), date(2024, 6, 28), date(2024, 9, 30),
+    date(2024, 12, 30), date(2025, 3, 31),
+]
+HOLD_DAYS = 365
+DATA_END = date(2026, 4, 24)
+HAIRCUT = 0.7
+TOPIX_CODE = "13060"
+SEED = 42
+
+
+def build_universe(engine, entry):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities, fa.net_income,
+                           fa.issued_shares, fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) * FROM visible
+                    ORDER BY sec_code, period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.net_income, l.issued_shares,
+                       d_now.adj_close price_now, d_now."marketCap" mc
+                FROM latest l
+                JOIN t_daily_stock_perf d_now
+                  ON d_now."ShokenCode" = l.sec_code AND d_now."Date" = :entry
+                  AND d_now.adj_close IS NOT NULL AND d_now."marketCap" IS NOT NULL
+                """
+            ),
+            {"entry": entry},
+        ).fetchall()
+    cols = ["sec_code", "current_assets", "total_liabilities", "investment_securities",
+            "net_income", "issued_shares", "price_now", "mc"]
+    df = pd.DataFrame(rows, columns=cols)
+    for c in cols[1:]:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df["ratio"] = (
+        df["current_assets"] - df["total_liabilities"]
+        + HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["mc"]
+    df["per"] = df["mc"] / df["net_income"]
+    return df
+
+
+def compute_returns(engine, codes, entry, deadline):
+    with engine.connect() as conn:
+        start_d = conn.execute(
+            text('SELECT MIN("Date") FROM t_daily_stock_perf WHERE "Date" >= :d'),
+            {"d": entry}).scalar()
+        end_d = conn.execute(
+            text('SELECT MAX("Date") FROM t_daily_stock_perf WHERE "Date" <= :d'),
+            {"d": deadline}).scalar()
+        prices = pd.DataFrame(
+            conn.execute(
+                text('SELECT "ShokenCode" sec_code, "Date" d, adj_close '
+                     'FROM t_daily_stock_perf WHERE "ShokenCode" = ANY(:codes) '
+                     'AND "Date" IN (:s, :e) AND adj_close IS NOT NULL'),
+                {"codes": codes, "s": start_d, "e": end_d},
+            ).fetchall(),
+            columns=["sec_code", "d", "adj_close"],
+        )
+    prices["adj_close"] = prices["adj_close"].astype(float)
+    out = {}
+    for sec, g in prices.groupby("sec_code"):
+        g = g.sort_values("d")
+        if len(g) < 2:
+            continue
+        out[sec] = (float(g.iloc[-1]["adj_close"]) / float(g.iloc[0]["adj_close"]) - 1) * 100
+    return out
+
+
+def topix_return(engine, entry, deadline):
+    with engine.connect() as conn:
+        s = conn.execute(
+            text('SELECT adj_close FROM t_daily_stock_perf '
+                 'WHERE "ShokenCode" = :c AND "Date" >= :d ORDER BY "Date" LIMIT 1'),
+            {"c": TOPIX_CODE, "d": entry}).scalar()
+        e = conn.execute(
+            text('SELECT adj_close FROM t_daily_stock_perf '
+                 'WHERE "ShokenCode" = :c AND "Date" <= :d ORDER BY "Date" DESC LIMIT 1'),
+            {"c": TOPIX_CODE, "d": deadline}).scalar()
+    return (float(e) / float(s) - 1) * 100
+
+
+def fetch_names(engine, codes):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text('SELECT DISTINCT ON ("secCode") "secCode", "filerName" '
+                 'FROM t_doc_list WHERE "secCode" = ANY(:codes) '
+                 'ORDER BY "secCode", "submitDateTime" DESC'),
+            {"codes": list(codes)}).fetchall()
+    return {c: n for c, n in rows}
+
+
+def sweet_spot(u, cap_band=(3e9, 30e9)):
+    cap_min, cap_max = cap_band
+    return u[(u["mc"] >= cap_min) & (u["mc"] <= cap_max)
+            & (u["ratio"] > 1.5) & (u["per"] > 0) & (u["per"] <= 10)
+            ].dropna(subset=["issued_shares"])
+
+
+def bootstrap_ci(arr, n_boot=10000, seed=42):
+    if len(arr) < 2:
+        return (np.nan, np.nan)
+    rng = np.random.default_rng(seed)
+    means = [rng.choice(arr, size=len(arr), replace=True).mean() for _ in range(n_boot)]
+    return float(np.percentile(means, 2.5)), float(np.percentile(means, 97.5))
+
+
+def run_strategy(per_entry, pick_fn, name):
+    """Apply pick_fn at each entry; return per-entry stats + all picks."""
+    per_entry_stats = []
+    pick_log = []  # list of (entry, sec_code, return_pct)
+    for entry, ctx in per_entry.items():
+        u = ctx["u"]; rets = ctx["rets"]; topix = ctx["topix"]
+        picks = pick_fn(u, entry)
+        if picks is None or picks.empty:
+            continue
+        codes = picks["sec_code"].tolist()
+        pr = [(c, rets[c]) for c in codes if c in rets]
+        if not pr:
+            continue
+        for c, r in pr:
+            pick_log.append({"entry": entry, "sec_code": c, "ret": r})
+        arr = np.array([r for _, r in pr])
+        per_entry_stats.append({
+            "entry": entry, "n": len(arr),
+            "mean": arr.mean(), "excess": arr.mean() - topix,
+            "median": float(np.median(arr)), "max": arr.max(), "min": arr.min(),
+            "neg_pct": (arr < 0).mean() * 100,
+        })
+    if not per_entry_stats:
+        return None
+    df = pd.DataFrame(per_entry_stats)
+    log = pd.DataFrame(pick_log)
+    avg_excess = df["excess"].mean()
+    win = (df["excess"] > 0).mean() * 100
+    ci = bootstrap_ci(df["excess"].tolist())
+    sharpe = avg_excess / df["mean"].std() if df["mean"].std() > 0 else float("nan")
+    return {
+        "name": name,
+        "df": df,
+        "log": log,
+        "avg_n": df["n"].mean(),
+        "avg_mean": df["mean"].mean(),
+        "avg_excess": avg_excess,
+        "ci_lo": ci[0], "ci_hi": ci[1],
+        "win_rate": win,
+        "avg_neg_pct": df["neg_pct"].mean(),
+        "sharpe": sharpe,
+    }
+
+
+def main():
+    engine = db.get_engine()
+    print("Pre-computing per-entry data...")
+    per_entry = {}
+    for entry in ENTRIES:
+        deadline = min(entry + timedelta(days=HOLD_DAYS), DATA_END)
+        u = build_universe(engine, entry)
+        rets = compute_returns(engine, u["sec_code"].tolist(), entry, deadline)
+        topix = topix_return(engine, entry, deadline)
+        per_entry[entry] = {"u": u, "rets": rets, "topix": topix}
+    print(f"  Avg TOPIX across {len(ENTRIES)} entries: "
+          f"{np.mean([ctx['topix'] for ctx in per_entry.values()]):+.1f}%\n")
+
+    rng = np.random.default_rng(SEED)
+
+    # Strategy factories
+    def f_lowest_float(pct):
+        def go(u, _entry):
+            s = sweet_spot(u)
+            if s.empty:
+                return s
+            n = max(1, int(len(s) * pct))
+            return s.nsmallest(n, "issued_shares")
+        return go
+
+    def f_lowest_mc(pct):
+        def go(u, _entry):
+            s = sweet_spot(u)
+            if s.empty:
+                return s
+            n = max(1, int(len(s) * pct))
+            return s.nsmallest(n, "mc")
+        return go
+
+    def f_random_subset(pct):
+        def go(u, _entry):
+            s = sweet_spot(u)
+            if s.empty:
+                return s
+            n = max(1, int(len(s) * pct))
+            return s.sample(n=min(n, len(s)), random_state=rng.integers(0, 2**31))
+        return go
+
+    def f_top10_ratio(_pct):
+        def go(u, _entry):
+            s = sweet_spot(u, cap_band=(3e9, 50e9))
+            return s.nlargest(10, "ratio")
+        return go
+
+    def f_baseline(_pct):
+        def go(u, _entry):
+            return sweet_spot(u, cap_band=(3e9, 50e9))
+        return go
+
+    strategies = []
+    for pct in (0.25, 0.33, 0.50):
+        strategies += [
+            (f"lowest_float_{int(pct*100)}", f_lowest_float(pct)),
+            (f"lowest_mc_{int(pct*100)}", f_lowest_mc(pct)),
+            (f"random_{int(pct*100)}", f_random_subset(pct)),
+        ]
+    strategies += [
+        ("top10_by_ratio", f_top10_ratio(0)),
+        ("baseline_sweet_3-50B", f_baseline(0)),
+    ]
+
+    print("=" * 130)
+    print("ATTRIBUTION: float vs mc vs random vs ratio-based, all within sweet-spot 3-30B (or 3-50B for last two)")
+    print("=" * 130)
+    print(
+        f"  {'strategy':<24}  {'avg_n':>5} {'avg_mean':>9} {'avg_excess':>11} {'95%CI':>22}"
+        f"  {'win':>4}  {'avg_neg':>8} {'sharpe':>7}"
+    )
+    print("-" * 130)
+    results = {}
+    for name, fn in strategies:
+        r = run_strategy(per_entry, fn, name)
+        if r is None:
+            continue
+        results[name] = r
+        print(
+            f"  {r['name']:<24}  {r['avg_n']:>5.1f} {r['avg_mean']:>+8.1f}% {r['avg_excess']:>+10.1f}% "
+            f"  [{r['ci_lo']:>+5.1f}, {r['ci_hi']:>+5.1f}]   "
+            f"{r['win_rate']:>3.0f}%  {r['avg_neg_pct']:>7.1f}% {r['sharpe']:>+7.2f}"
+        )
+
+    # Recurrence analysis: at lowest_float_33, how concentrated is the strategy on a few stocks?
+    print("\n\n" + "=" * 130)
+    print("RECURRENCE: how often each pick appears across 10 entries (lowest_float_33)")
+    print("=" * 130)
+    log = results["lowest_float_33"]["log"]
+    all_codes = log["sec_code"].unique()
+    names = fetch_names(engine, list(all_codes))
+    counts = (
+        log.groupby("sec_code")
+        .agg(times_picked=("ret", "size"), avg_ret=("ret", "mean"),
+             min_ret=("ret", "min"), max_ret=("ret", "max"))
+        .sort_values("times_picked", ascending=False)
+    )
+    print(f"  Total picks across 10 entries: {len(log)}")
+    print(f"  Unique stocks: {len(counts)}")
+    print(f"  {'code':<6} {'name':<28} {'times':>5} {'avg_ret':>8} {'min':>7} {'max':>7}")
+    for code, row in counts.iterrows():
+        print(
+            f"  {code:<6} {names.get(code, '')[:28]:<28} {int(row['times_picked']):>5} "
+            f"{row['avg_ret']:>+7.1f}% {row['min_ret']:>+6.1f}% {row['max_ret']:>+6.1f}%"
+        )
+
+    # Holdout: re-run with the most-recurring stock removed from universe
+    print("\n\n" + "=" * 130)
+    print("HOLDOUT: lowest_float_33 with the single most-recurring stock removed")
+    print("=" * 130)
+    top_recurring = counts.index[0]
+    print(f"  Excluding: {top_recurring}  {names.get(top_recurring, '')}")
+    def f_lowest_float_excl(pct, exclude_code):
+        def go(u, _entry):
+            s = sweet_spot(u)
+            s = s[s["sec_code"] != exclude_code]
+            if s.empty:
+                return s
+            n = max(1, int(len(s) * pct))
+            return s.nsmallest(n, "issued_shares")
+        return go
+    r_holdout = run_strategy(per_entry, f_lowest_float_excl(0.33, top_recurring),
+                             f"lowest_float_33_excl_{top_recurring}")
+    print(
+        f"  avg_n={r_holdout['avg_n']:.1f}  avg_mean={r_holdout['avg_mean']:+.1f}%  "
+        f"avg_excess={r_holdout['avg_excess']:+.1f}%  "
+        f"CI[{r_holdout['ci_lo']:+.1f}, {r_holdout['ci_hi']:+.1f}]  "
+        f"win={r_holdout['win_rate']:.0f}%  sharpe={r_holdout['sharpe']:+.2f}"
+    )
+
+    # Per-pick distribution dump for the most concentrated robust threshold
+    print("\n\n" + "=" * 130)
+    print("PER-PICK DISTRIBUTION across all 10 entries (lowest_float_33, cap 3-30B)")
+    print("=" * 130)
+    rets_arr = log["ret"].values
+    s = pd.Series(rets_arr)
+    print(f"  total picks: {len(s)}")
+    print(f"  mean {s.mean():+.1f}%  median {s.median():+.1f}%  stdev {s.std():.1f}%")
+    print(f"  P10 {s.quantile(0.10):+.1f}  P25 {s.quantile(0.25):+.1f}  "
+          f"P75 {s.quantile(0.75):+.1f}  P90 {s.quantile(0.90):+.1f}")
+    print(f"  min {s.min():+.1f}  max {s.max():+.1f}  skew {s.skew():.2f}")
+    buckets = [
+        ("<-25%",     s < -25),
+        ("-25 to 0",  (s >= -25) & (s < 0)),
+        ("0 to 25",   (s >= 0) & (s < 25)),
+        ("25 to 50",  (s >= 25) & (s < 50)),
+        ("50 to 100", (s >= 50) & (s < 100)),
+        (">=100",     s >= 100),
+    ]
+    for label, mask in buckets:
+        n = mask.sum()
+        pct = n / len(s) * 100
+        bar = "█" * int(pct / 2)
+        print(f"  {label:>10}: n={n:>3} ({pct:>4.0f}%) {bar}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hybrid_montecarlo.py
+++ b/scripts/hybrid_montecarlo.py
@@ -1,0 +1,294 @@
+"""Monte Carlo validation of the low_float edge + current picks.
+
+The attribution script showed lowest_float_33 has +24.5pp excess vs
+lowest_mc_33 (+6.3pp) and random_33 (+16.4pp from a single seed).
+Single-seed random is noisy. This script runs 500 random subsets per
+entry and reports the empirical distribution — i.e., what percentile
+does lowest_float fall in vs random selection of the same size?
+
+Also emits the current picks (today's universe) at the recommended
+threshold so the user has actionable output.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+
+ENTRIES = [
+    date(2022, 12, 30), date(2023, 3, 31), date(2023, 6, 30), date(2023, 9, 29),
+    date(2023, 12, 29), date(2024, 3, 29), date(2024, 6, 28), date(2024, 9, 30),
+    date(2024, 12, 30), date(2025, 3, 31),
+]
+HOLD_DAYS = 365
+DATA_END = date(2026, 4, 24)
+HAIRCUT = 0.7
+TOPIX_CODE = "13060"
+N_RANDOM = 500
+
+
+def build_universe(engine, entry):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities, fa.net_income,
+                           fa.issued_shares, fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) * FROM visible
+                    ORDER BY sec_code, period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.net_income, l.issued_shares,
+                       d_now.adj_close price_now, d_now."marketCap" mc
+                FROM latest l
+                JOIN t_daily_stock_perf d_now
+                  ON d_now."ShokenCode" = l.sec_code AND d_now."Date" = :entry
+                  AND d_now.adj_close IS NOT NULL AND d_now."marketCap" IS NOT NULL
+                """
+            ),
+            {"entry": entry},
+        ).fetchall()
+    cols = ["sec_code", "current_assets", "total_liabilities", "investment_securities",
+            "net_income", "issued_shares", "price_now", "mc"]
+    df = pd.DataFrame(rows, columns=cols)
+    for c in cols[1:]:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df["ratio"] = (
+        df["current_assets"] - df["total_liabilities"]
+        + HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["mc"]
+    df["per"] = df["mc"] / df["net_income"]
+    return df
+
+
+def build_universe_today(engine, entry):
+    """Like build_universe but doesn't require entry-day price (for live
+    screening)."""
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities, fa.net_income,
+                           fa.issued_shares, fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) * FROM visible
+                    ORDER BY sec_code, period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.net_income, l.issued_shares,
+                       l.period_end,
+                       d_now.adj_close price_now, d_now."marketCap" mc, d_now."Date" pd
+                FROM latest l
+                JOIN LATERAL (
+                    SELECT adj_close, "marketCap", "Date" FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code AND p."Date" <= :entry
+                      AND p.adj_close IS NOT NULL AND p."marketCap" IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d_now ON TRUE
+                """
+            ),
+            {"entry": entry},
+        ).fetchall()
+    cols = ["sec_code", "current_assets", "total_liabilities", "investment_securities",
+            "net_income", "issued_shares", "period_end",
+            "price_now", "mc", "price_date"]
+    df = pd.DataFrame(rows, columns=cols)
+    for c in ("current_assets", "total_liabilities", "investment_securities",
+              "net_income", "issued_shares", "price_now", "mc"):
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df["ratio"] = (
+        df["current_assets"] - df["total_liabilities"]
+        + HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["mc"]
+    df["per"] = df["mc"] / df["net_income"]
+    return df
+
+
+def compute_returns(engine, codes, entry, deadline):
+    with engine.connect() as conn:
+        start_d = conn.execute(
+            text('SELECT MIN("Date") FROM t_daily_stock_perf WHERE "Date" >= :d'),
+            {"d": entry}).scalar()
+        end_d = conn.execute(
+            text('SELECT MAX("Date") FROM t_daily_stock_perf WHERE "Date" <= :d'),
+            {"d": deadline}).scalar()
+        prices = pd.DataFrame(
+            conn.execute(
+                text('SELECT "ShokenCode" sec_code, "Date" d, adj_close '
+                     'FROM t_daily_stock_perf WHERE "ShokenCode" = ANY(:codes) '
+                     'AND "Date" IN (:s, :e) AND adj_close IS NOT NULL'),
+                {"codes": codes, "s": start_d, "e": end_d},
+            ).fetchall(),
+            columns=["sec_code", "d", "adj_close"],
+        )
+    prices["adj_close"] = prices["adj_close"].astype(float)
+    out = {}
+    for sec, g in prices.groupby("sec_code"):
+        g = g.sort_values("d")
+        if len(g) < 2:
+            continue
+        out[sec] = (float(g.iloc[-1]["adj_close"]) / float(g.iloc[0]["adj_close"]) - 1) * 100
+    return out
+
+
+def topix_return(engine, entry, deadline):
+    with engine.connect() as conn:
+        s = conn.execute(
+            text('SELECT adj_close FROM t_daily_stock_perf '
+                 'WHERE "ShokenCode" = :c AND "Date" >= :d ORDER BY "Date" LIMIT 1'),
+            {"c": TOPIX_CODE, "d": entry}).scalar()
+        e = conn.execute(
+            text('SELECT adj_close FROM t_daily_stock_perf '
+                 'WHERE "ShokenCode" = :c AND "Date" <= :d ORDER BY "Date" DESC LIMIT 1'),
+            {"c": TOPIX_CODE, "d": deadline}).scalar()
+    return (float(e) / float(s) - 1) * 100
+
+
+def fetch_names(engine, codes):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text('SELECT DISTINCT ON ("secCode") "secCode", "filerName" '
+                 'FROM t_doc_list WHERE "secCode" = ANY(:codes) '
+                 'ORDER BY "secCode", "submitDateTime" DESC'),
+            {"codes": list(codes)}).fetchall()
+    return {c: n for c, n in rows}
+
+
+def sweet_spot(u, cap_band=(3e9, 30e9)):
+    cap_min, cap_max = cap_band
+    return u[(u["mc"] >= cap_min) & (u["mc"] <= cap_max)
+            & (u["ratio"] > 1.5) & (u["per"] > 0) & (u["per"] <= 10)
+            ].dropna(subset=["issued_shares"])
+
+
+def main():
+    engine = db.get_engine()
+    print("Pre-computing per-entry data...")
+    per_entry = {}
+    for entry in ENTRIES:
+        deadline = min(entry + timedelta(days=HOLD_DAYS), DATA_END)
+        u = build_universe(engine, entry)
+        rets = compute_returns(engine, u["sec_code"].tolist(), entry, deadline)
+        topix = topix_return(engine, entry, deadline)
+        per_entry[entry] = {"u": u, "rets": rets, "topix": topix, "deadline": deadline}
+
+    # Monte Carlo: at each threshold, run lowest_float once + random N_RANDOM times
+    print("\n" + "=" * 130)
+    print(f"MONTE CARLO: lowest_float vs random subset of same size ({N_RANDOM} samples per entry)")
+    print("=" * 130)
+    rng = np.random.default_rng(42)
+    for pct in (0.25, 0.33, 0.50):
+        # actual lowest_float per-entry mean excess
+        lf_per_entry = []
+        rand_per_entry = []  # list of arrays (N_RANDOM samples per entry)
+        for entry, ctx in per_entry.items():
+            sweet = sweet_spot(ctx["u"])
+            if sweet.empty:
+                continue
+            n = max(1, int(len(sweet) * pct))
+            picks = sweet.nsmallest(n, "issued_shares")
+            pr = [ctx["rets"][c] for c in picks["sec_code"] if c in ctx["rets"]]
+            if not pr:
+                continue
+            lf_per_entry.append(np.mean(pr) - ctx["topix"])
+
+            # random samples
+            sweet_with_rets = sweet[sweet["sec_code"].isin(ctx["rets"].keys())]
+            sweet_rets = sweet_with_rets["sec_code"].map(ctx["rets"]).values
+            if len(sweet_rets) < n:
+                continue
+            samples = []
+            for _ in range(N_RANDOM):
+                idx = rng.choice(len(sweet_rets), size=n, replace=False)
+                samples.append(sweet_rets[idx].mean() - ctx["topix"])
+            rand_per_entry.append(np.array(samples))
+
+        # actual: average across entries
+        lf_mean = np.mean(lf_per_entry)
+
+        # random null distribution: average across entries, per draw
+        if len(rand_per_entry) == len(lf_per_entry):
+            null_means = np.mean(np.stack(rand_per_entry), axis=0)
+            pct_above = (null_means >= lf_mean).mean() * 100
+            null_lo = np.percentile(null_means, 2.5)
+            null_hi = np.percentile(null_means, 97.5)
+            null_mean = null_means.mean()
+            print(
+                f"\n  threshold={pct*100:.0f}%  n_per_entry≈{int(len(lf_per_entry) and pct * 50):>2}"
+            )
+            print(f"    lowest_float avg excess: {lf_mean:+6.1f}pp")
+            print(f"    random null mean:        {null_mean:+6.1f}pp  "
+                  f"(95% range: [{null_lo:+5.1f}, {null_hi:+5.1f}])")
+            print(f"    p-value (random ≥ float): {pct_above/100:.3f}  "
+                  f"({pct_above:.1f}% of random draws beat lowest_float)")
+
+    # Current picks at recommended threshold (33% within sweet-spot, cap 3-30B)
+    print("\n\n" + "=" * 130)
+    print("CURRENT PICKS (today's universe at recommended threshold = 33% within sweet-spot 3-30B)")
+    print("=" * 130)
+    today = date.today()
+    u_now = build_universe_today(engine, today)
+    sweet_now = sweet_spot(u_now, cap_band=(3e9, 30e9))
+    if not sweet_now.empty:
+        n_low = max(1, int(len(sweet_now) * 0.33))
+        picks_now = sweet_now.nsmallest(n_low, "issued_shares").copy()
+        names_now = fetch_names(engine, picks_now["sec_code"].tolist())
+        picks_now["name"] = picks_now["sec_code"].map(names_now)
+        picks_now["mc_bn"] = picks_now["mc"] / 1e9
+        picks_now["shares_M"] = picks_now["issued_shares"] / 1e6
+        picks_now = picks_now.sort_values("issued_shares")
+        print(f"  Sweet-spot universe today: {len(sweet_now)}  →  picking lowest-float {n_low}")
+        print(f"  {'code':<6} {'name':<32} {'ratio':>5} {'PER':>5} {'MC ¥B':>6} {'shares M':>9} {'price':>8} {'period':>11}")
+        for _, r in picks_now.iterrows():
+            print(
+                f"  {r['sec_code']:<6} {(r['name'] or '')[:32]:<32} "
+                f"{r['ratio']:>5.2f} {r['per']:>5.1f} {r['mc_bn']:>6.1f} "
+                f"{r['shares_M']:>9.2f} ¥{r['price_now']:>7.0f} {str(r['period_end']):>11}"
+            )
+
+    # Also at 50% threshold for those wanting more diversification
+    print("\n  Also at 50% threshold (n=5-7 typical, more diversified):")
+    if not sweet_now.empty:
+        n_med = max(1, int(len(sweet_now) * 0.50))
+        picks_50 = sweet_now.nsmallest(n_med, "issued_shares").copy()
+        names_50 = fetch_names(engine, picks_50["sec_code"].tolist())
+        picks_50["name"] = picks_50["sec_code"].map(names_50)
+        picks_50["mc_bn"] = picks_50["mc"] / 1e9
+        picks_50["shares_M"] = picks_50["issued_shares"] / 1e6
+        picks_50 = picks_50.sort_values("issued_shares")
+        for _, r in picks_50.iterrows():
+            print(
+                f"  {r['sec_code']:<6} {(r['name'] or '')[:32]:<32} "
+                f"{r['ratio']:>5.2f} {r['per']:>5.1f} {r['mc_bn']:>6.1f} "
+                f"{r['shares_M']:>9.2f}M shares"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hybrid_sweep.py
+++ b/scripts/hybrid_sweep.py
@@ -1,0 +1,289 @@
+"""Threshold sweep on the low_float_with_value hybrid strategy.
+10 quarterly entry dates × 7 float thresholds × 12-month buy-and-hold.
+
+Goal: find the diversification-vs-concentration sweet spot for the
+hybrid (sweet-spot net-cash + bottom X% by issued shares within that
+subset). Single-cohort showed +32pp excess at 25%; need to confirm
+across many entries and pick a robust threshold.
+
+Diagnostics beyond mean return:
+- Per-entry mean stability (is edge consistent or driven by 1-2 windows?)
+- Concentration check (does the strategy lean on outlier picks?)
+- Bootstrapped confidence on average excess
+- Cohort-by-cohort win rate vs TOPIX
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+
+ENTRIES = [
+    date(2022, 12, 30),
+    date(2023, 3, 31),
+    date(2023, 6, 30),
+    date(2023, 9, 29),
+    date(2023, 12, 29),
+    date(2024, 3, 29),
+    date(2024, 6, 28),
+    date(2024, 9, 30),
+    date(2024, 12, 30),
+    date(2025, 3, 31),
+]
+HOLD_DAYS = 365
+DATA_END = date(2026, 4, 24)
+HAIRCUT = 0.7
+TOPIX_CODE = "13060"
+
+FLOAT_THRESHOLDS = [0.10, 0.25, 0.33, 0.50, 0.75, 1.00]  # 1.0 = no float filter
+# Cap bands to test (min, max) in JPY
+CAP_BANDS = {
+    "3-30B": (3e9, 30e9),
+    "3-50B": (3e9, 50e9),
+    "3-15B": (3e9, 15e9),
+}
+
+
+def build_universe(engine, entry):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities,
+                           fa.net_income, fa.issued_shares,
+                           fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) * FROM visible
+                    ORDER BY sec_code, period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.net_income, l.issued_shares,
+                       d_now.adj_close price_now, d_now."marketCap" mc
+                FROM latest l
+                JOIN t_daily_stock_perf d_now
+                  ON d_now."ShokenCode" = l.sec_code AND d_now."Date" = :entry
+                  AND d_now.adj_close IS NOT NULL AND d_now."marketCap" IS NOT NULL
+                """
+            ),
+            {"entry": entry},
+        ).fetchall()
+    cols = [
+        "sec_code", "current_assets", "total_liabilities", "investment_securities",
+        "net_income", "issued_shares", "price_now", "mc",
+    ]
+    df = pd.DataFrame(rows, columns=cols)
+    for c in cols[1:]:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df["ratio"] = (
+        df["current_assets"] - df["total_liabilities"]
+        + HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["mc"]
+    df["per"] = df["mc"] / df["net_income"]
+    return df
+
+
+def compute_returns(engine, codes, entry, deadline):
+    with engine.connect() as conn:
+        # Find first trading day at or after entry
+        start_d = conn.execute(
+            text('SELECT MIN("Date") FROM t_daily_stock_perf WHERE "Date" >= :d'),
+            {"d": entry}).scalar()
+        # Find last trading day at or before deadline
+        end_d = conn.execute(
+            text('SELECT MAX("Date") FROM t_daily_stock_perf WHERE "Date" <= :d'),
+            {"d": deadline}).scalar()
+        prices = pd.DataFrame(
+            conn.execute(
+                text(
+                    'SELECT "ShokenCode" sec_code, "Date" d, adj_close '
+                    'FROM t_daily_stock_perf WHERE "ShokenCode" = ANY(:codes) '
+                    'AND "Date" IN (:s, :e) AND adj_close IS NOT NULL'
+                ),
+                {"codes": codes, "s": start_d, "e": end_d},
+            ).fetchall(),
+            columns=["sec_code", "d", "adj_close"],
+        )
+    prices["adj_close"] = prices["adj_close"].astype(float)
+    out = {}
+    for sec, g in prices.groupby("sec_code"):
+        g = g.sort_values("d")
+        if len(g) < 2:
+            continue
+        ent_p = float(g.iloc[0]["adj_close"])
+        ext_p = float(g.iloc[-1]["adj_close"])
+        out[sec] = (ext_p / ent_p - 1) * 100
+    return out
+
+
+def topix_return(engine, entry, deadline):
+    with engine.connect() as conn:
+        s = conn.execute(
+            text('SELECT adj_close FROM t_daily_stock_perf '
+                 'WHERE "ShokenCode" = :c AND "Date" >= :d ORDER BY "Date" LIMIT 1'),
+            {"c": TOPIX_CODE, "d": entry}).scalar()
+        e = conn.execute(
+            text('SELECT adj_close FROM t_daily_stock_perf '
+                 'WHERE "ShokenCode" = :c AND "Date" <= :d ORDER BY "Date" DESC LIMIT 1'),
+            {"c": TOPIX_CODE, "d": deadline}).scalar()
+    return (float(e) / float(s) - 1) * 100
+
+
+def hybrid_picks(u, cap_band, float_pct):
+    cap_min, cap_max = cap_band
+    sweet = u[(u["mc"] >= cap_min) & (u["mc"] <= cap_max)
+            & (u["ratio"] > 1.5) & (u["per"] > 0) & (u["per"] <= 10)
+            ].dropna(subset=["issued_shares"])
+    if sweet.empty:
+        return sweet
+    if float_pct >= 1.0:
+        return sweet
+    n = max(1, int(len(sweet) * float_pct))
+    return sweet.nsmallest(n, "issued_shares")
+
+
+def bootstrap_excess_ci(per_entry_excess, n_boot=10000, seed=42):
+    """95% CI on the across-entries mean excess return via bootstrap."""
+    arr = np.array(per_entry_excess)
+    if len(arr) < 2:
+        return (np.nan, np.nan)
+    rng = np.random.default_rng(seed)
+    means = []
+    for _ in range(n_boot):
+        sample = rng.choice(arr, size=len(arr), replace=True)
+        means.append(sample.mean())
+    return (float(np.percentile(means, 2.5)), float(np.percentile(means, 97.5)))
+
+
+def main():
+    engine = db.get_engine()
+
+    # Pre-compute per-entry universe + returns once (shared across thresholds)
+    print("Pre-computing universes & returns for", len(ENTRIES), "entries...")
+    per_entry: dict[date, dict] = {}
+    for entry in ENTRIES:
+        deadline = min(entry + timedelta(days=HOLD_DAYS), DATA_END)
+        u = build_universe(engine, entry)
+        rets = compute_returns(engine, u["sec_code"].tolist(), entry, deadline)
+        topix = topix_return(engine, entry, deadline)
+        per_entry[entry] = {"u": u, "rets": rets, "topix": topix, "deadline": deadline}
+        n_visible = (u["sec_code"].isin(rets.keys())).sum()
+        print(f"  {entry} → {deadline}  univ={len(u):>5}  with_ret={n_visible:>5}  topix={topix:+5.1f}%")
+
+    # Sweep: cap_band × float_pct
+    print("\n\n" + "=" * 130)
+    print("HYBRID SWEEP: per-threshold aggregate across", len(ENTRIES), "quarterly entries (12-mo hold)")
+    print("=" * 130)
+    for band_name, band in CAP_BANDS.items():
+        print(f"\n--- cap_band = {band_name} ---")
+        print(
+            f"{'float%':>8}  {'avg_n':>6}  {'avg_mean':>9} {'avg_excess':>11} "
+            f"{'95%CI':>22}  {'win_rate':>9} {'avg_pos%':>9} {'avg_max':>9}  {'sharpe':>7}"
+        )
+        print("-" * 130)
+        all_results = {}
+        for fpct in FLOAT_THRESHOLDS:
+            per_entry_stats = []
+            all_picks = []
+            for entry in ENTRIES:
+                u = per_entry[entry]["u"]
+                rets = per_entry[entry]["rets"]
+                topix = per_entry[entry]["topix"]
+                picks = hybrid_picks(u, band, fpct)
+                pick_rets = [rets[c] for c in picks["sec_code"] if c in rets]
+                if not pick_rets:
+                    continue
+                s = np.array(pick_rets)
+                per_entry_stats.append({
+                    "entry": entry,
+                    "n": len(s),
+                    "mean": s.mean(),
+                    "excess": s.mean() - topix,
+                    "max": s.max(),
+                    "neg_pct": (s < 0).mean() * 100,
+                })
+                all_picks.extend(s.tolist())
+            if not per_entry_stats:
+                continue
+            df = pd.DataFrame(per_entry_stats)
+            avg_n = df["n"].mean()
+            avg_mean = df["mean"].mean()
+            avg_excess = df["excess"].mean()
+            avg_max = df["max"].mean()
+            avg_neg = df["neg_pct"].mean()
+            avg_pos = 100 - avg_neg
+            win_rate = (df["excess"] > 0).mean() * 100
+            ci_lo, ci_hi = bootstrap_excess_ci(df["excess"].tolist())
+            # Sharpe-like: avg_excess / stdev of per-entry means
+            sharpe = avg_excess / df["mean"].std() if df["mean"].std() > 0 else float("nan")
+            print(
+                f"{fpct*100:>7.0f}%  {avg_n:>6.1f}  {avg_mean:>+8.1f}% {avg_excess:>+10.1f}% "
+                f"  [{ci_lo:>+5.1f}, {ci_hi:>+5.1f}]   "
+                f"{win_rate:>7.0f}% {avg_pos:>8.1f}% {avg_max:>+8.0f}%  {sharpe:>+7.2f}"
+            )
+            all_results[fpct] = {"per_entry": df, "all_picks": all_picks}
+
+    # Drill: best threshold per cap band, show per-entry detail
+    print("\n\n" + "=" * 130)
+    print("DRILL: per-entry detail at the most concentrated threshold (25%) and broadest (100%) for cap=3-30B")
+    print("=" * 130)
+    for fpct in [0.25, 0.50, 1.00]:
+        print(f"\n  --- float% = {fpct*100:.0f}%, cap=3-30B ---")
+        print(f"  {'entry':<12} {'n':>3} {'mean':>7} {'topix':>7} {'excess':>7} {'max':>7} {'neg%':>5}  picks (top 3)")
+        for entry in ENTRIES:
+            u = per_entry[entry]["u"]
+            rets = per_entry[entry]["rets"]
+            topix = per_entry[entry]["topix"]
+            picks = hybrid_picks(u, (3e9, 30e9), fpct)
+            pr = [(c, rets[c]) for c in picks["sec_code"] if c in rets]
+            if not pr:
+                print(f"  {entry.isoformat():<12} {'(0)':>3} {'-':>7} {topix:>+6.1f}%")
+                continue
+            arr = np.array([r for _, r in pr])
+            top3 = sorted(pr, key=lambda x: -x[1])[:3]
+            top3s = " | ".join(f"{c}:{r:+.0f}%" for c, r in top3)
+            print(
+                f"  {entry.isoformat():<12} {len(arr):>3} {arr.mean():>+6.1f}% {topix:>+6.1f}% "
+                f"{arr.mean()-topix:>+6.1f}% {arr.max():>+6.0f}% {(arr<0).mean()*100:>4.0f}%  {top3s}"
+            )
+
+    # Concentration check: is the edge driven by outliers?
+    print("\n\n" + "=" * 130)
+    print("CONCENTRATION CHECK (cap=3-30B, float%=25): excess vs TOPIX with/without max-return pick removed per entry")
+    print("=" * 130)
+    print(f"  {'entry':<12} {'n':>3} {'mean_all':>9} {'mean_excl_top':>13} {'topix':>7} {'edge w/top':>11} {'edge w/o top':>13}")
+    for entry in ENTRIES:
+        u = per_entry[entry]["u"]
+        rets = per_entry[entry]["rets"]
+        topix = per_entry[entry]["topix"]
+        picks = hybrid_picks(u, (3e9, 30e9), 0.25)
+        pr = [rets[c] for c in picks["sec_code"] if c in rets]
+        if len(pr) < 2:
+            continue
+        arr = np.array(pr)
+        without_max = arr[arr != arr.max()]
+        print(
+            f"  {entry.isoformat():<12} {len(arr):>3} {arr.mean():>+8.1f}% "
+            f"{without_max.mean():>+12.1f}% {topix:>+6.1f}% "
+            f"{arr.mean()-topix:>+10.1f}% {without_max.mean()-topix:>+12.1f}%"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/moonshot_lab.py
+++ b/scripts/moonshot_lab.py
@@ -1,0 +1,295 @@
+"""Moonshot search: do non-value strategies have the fat right tails
+that net-cash value lacks? net-cash caps out around +180% over 3 years
+(no stock in our universe exceeded +200%). This lab tests whether
+momentum / earnings-acceleration / small-cap-anomaly strategies
+produce the >+300% rockets that net-cash investing doesn't.
+
+Setup: same window as strategy_lab.py (entry 2022-12-30, exit on the
+deadline 2025-12-30 — no ratio<1 exit because most of these don't
+have a ratio). Universe: all stocks with adj_close + financials.
+
+Strategies tested:
+1. earnings_rocket — small-cap (≤¥30B) + op_yoy > +100% (acceleration)
+2. price_momentum — top decile 12m momentum within small-cap
+3. high_growth — small-cap + sales_yoy > +30% (top-line rocket)
+4. micro_momentum — micro-cap (≤¥10B) + 6m_mom > +30%
+5. earnings_x_momentum — op_yoy > +50% AND mom_6m > +10%
+6. roa_x_momentum — op_yield > +20% AND mom_6m > +20%
+7. low_float_proxy — bottom decile by issued_shares within small-cap +
+   any momentum (proxy for small-float since we don't have free-float)
+8. random_smallcap (n=30) — control: random 30 small caps for shape ref
+
+For each, prints distribution stats + bucket histogram + top 10 picks.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+
+ENTRY = date(2022, 12, 30)
+DEADLINE = date(2025, 12, 30)
+TOPIX_3Y = 81.2
+RNG_SEED = 42
+
+
+def build_universe(engine):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities, fa.operating_income,
+                           fa.net_sales, fa.net_income, fa.issued_shares,
+                           fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) * FROM visible
+                    ORDER BY sec_code, period_end DESC
+                ),
+                ranked AS (
+                    SELECT fa2."secCode", fa2.period_end,
+                           fa2.operating_income, fa2.net_sales,
+                           LAG(fa2.operating_income) OVER w op_prev,
+                           LAG(fa2.net_sales) OVER w sales_prev
+                    FROM t_financials_annual fa2
+                    JOIN t_doc_list dl2 ON dl2."docID" = fa2.source_doc_id
+                    WHERE dl2."submitDateTime"::date <= :entry
+                    WINDOW w AS (PARTITION BY fa2."secCode" ORDER BY fa2.period_end)
+                ),
+                yoy AS (
+                    SELECT DISTINCT ON ("secCode") "secCode" sec_code, op_prev, sales_prev
+                    FROM ranked WHERE op_prev IS NOT NULL OR sales_prev IS NOT NULL
+                    ORDER BY "secCode", period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.operating_income,
+                       l.net_sales, l.net_income, l.issued_shares,
+                       y.op_prev, y.sales_prev,
+                       d_now.adj_close price_now, d_now."marketCap" mc,
+                       d_6mo.adj_close p_6mo, d_12mo.adj_close p_12mo
+                FROM latest l
+                LEFT JOIN yoy y ON y.sec_code = l.sec_code
+                JOIN t_daily_stock_perf d_now
+                  ON d_now."ShokenCode" = l.sec_code AND d_now."Date" = :entry
+                  AND d_now.adj_close IS NOT NULL AND d_now."marketCap" IS NOT NULL
+                LEFT JOIN LATERAL (
+                    SELECT adj_close FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code
+                      AND p."Date" BETWEEN :s6_start AND :s6_end
+                      AND p.adj_close IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d_6mo ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT adj_close FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code
+                      AND p."Date" BETWEEN :s12_start AND :s12_end
+                      AND p.adj_close IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d_12mo ON TRUE
+                """
+            ),
+            {
+                "entry": ENTRY,
+                "s6_start": ENTRY - timedelta(days=200),
+                "s6_end": ENTRY - timedelta(days=160),
+                "s12_start": ENTRY - timedelta(days=380),
+                "s12_end": ENTRY - timedelta(days=350),
+            },
+        ).fetchall()
+    cols = [
+        "sec_code", "current_assets", "total_liabilities", "investment_securities",
+        "operating_income", "net_sales", "net_income", "issued_shares",
+        "op_prev", "sales_prev", "price_now", "mc", "p_6mo", "p_12mo",
+    ]
+    df = pd.DataFrame(rows, columns=cols)
+    for c in cols[1:]:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df["op_yield"] = df["operating_income"] / df["mc"]
+    df["op_yoy"] = (df["operating_income"] - df["op_prev"]) / df["op_prev"].abs()
+    df["sales_yoy"] = (df["net_sales"] - df["sales_prev"]) / df["sales_prev"]
+    df["mom_6m"] = df["price_now"] / df["p_6mo"] - 1
+    df["mom_12m"] = df["price_now"] / df["p_12mo"] - 1
+    df["per"] = df["mc"] / df["net_income"]
+    return df
+
+
+def compute_returns(engine, sec_codes):
+    """Buy-and-hold to deadline (no exit rule)."""
+    with engine.connect() as conn:
+        prices = pd.DataFrame(
+            conn.execute(
+                text(
+                    'SELECT "ShokenCode" sec_code, "Date" d, adj_close '
+                    'FROM t_daily_stock_perf '
+                    'WHERE "ShokenCode" = ANY(:codes) AND "Date" IN (:s, :e) '
+                    'AND adj_close IS NOT NULL '
+                    'UNION ALL '
+                    'SELECT "ShokenCode" sec_code, "Date" d, adj_close '
+                    'FROM t_daily_stock_perf '
+                    'WHERE "ShokenCode" = ANY(:codes) '
+                    'AND "Date" = (SELECT MAX("Date") FROM t_daily_stock_perf WHERE "Date" <= :e) '
+                    'AND adj_close IS NOT NULL'
+                ),
+                {"codes": sec_codes, "s": ENTRY, "e": DEADLINE},
+            ).fetchall(),
+            columns=["sec_code", "d", "adj_close"],
+        )
+    if prices.empty:
+        return {}
+    prices["adj_close"] = prices["adj_close"].astype(float)
+    out = {}
+    for sec_code, g in prices.groupby("sec_code"):
+        g = g.sort_values("d")
+        if len(g) < 2:
+            continue
+        ent = g.iloc[0]
+        ext = g.iloc[-1]
+        if ent["d"] != ENTRY:
+            continue
+        out[sec_code] = {"return_pct": (float(ext["adj_close"]) / float(ent["adj_close"]) - 1) * 100}
+    return out
+
+
+def fetch_names(engine, sec_codes):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                'SELECT DISTINCT ON ("secCode") "secCode", "filerName" '
+                'FROM t_doc_list WHERE "secCode" = ANY(:codes) '
+                'ORDER BY "secCode", "submitDateTime" DESC'
+            ),
+            {"codes": list(sec_codes)},
+        ).fetchall()
+    return {c: n for c, n in rows}
+
+
+def report(name, picks, returns, names):
+    rs = []
+    for code in picks["sec_code"]:
+        if code in returns:
+            rs.append({
+                "code": code,
+                "name": names.get(code, ""),
+                "mc_bn": picks.set_index("sec_code").loc[code, "mc"] / 1e9,
+                "ret_pct": returns[code]["return_pct"],
+            })
+    if not rs:
+        print(f"\n=== {name} === (no stocks)")
+        return
+    df = pd.DataFrame(rs).sort_values("ret_pct", ascending=False).reset_index(drop=True)
+    s = df["ret_pct"]
+
+    print(f"\n{'='*100}")
+    print(f"{name}  —  n={len(df)}")
+    print("=" * 100)
+    print(
+        f"  mean {s.mean():+6.1f}%  median {s.median():+6.1f}%  stdev {s.std():>5.1f}%  "
+        f"min {s.min():+6.1f}%  max {s.max():+6.1f}%  skew {s.skew():>5.2f}"
+    )
+    print(
+        f"  P10 {s.quantile(0.10):+6.1f}%  P25 {s.quantile(0.25):+6.1f}%  "
+        f"P75 {s.quantile(0.75):+6.1f}%  P90 {s.quantile(0.90):+6.1f}%  P95 {s.quantile(0.95):+6.1f}%"
+    )
+    buckets = [
+        ("<-50%",     s < -50),
+        ("-50 to 0",  (s >= -50) & (s < 0)),
+        ("0 to 50",   (s >= 0) & (s < 50)),
+        ("50 to 100", (s >= 50) & (s < 100)),
+        ("100-200",   (s >= 100) & (s < 200)),
+        ("200-300",   (s >= 200) & (s < 300)),
+        (">=300",     s >= 300),
+    ]
+    print(f"  buckets:")
+    for label, mask in buckets:
+        n = mask.sum()
+        pct = n / len(df) * 100
+        bar = "█" * int(pct / 2)
+        print(f"    {label:>10}: n={n:>3} ({pct:>4.0f}%) {bar}")
+    n_topix = (s > TOPIX_3Y).sum()
+    n_double = (s >= 100).sum()
+    n_triple = (s >= 200).sum()
+    n_neg = (s < 0).sum()
+    print(
+        f"  beat TOPIX ({n_topix}, {n_topix/len(df)*100:.0f}%) | "
+        f"doubled ({n_double}, {n_double/len(df)*100:.0f}%) | "
+        f"tripled ({n_triple}, {n_triple/len(df)*100:.0f}%) | "
+        f"negative ({n_neg}, {n_neg/len(df)*100:.0f}%)"
+    )
+    print(f"  top 10 picks:")
+    for i, row in df.head(10).iterrows():
+        print(f"    {i+1:>2}. {row['code']:<6} {row['name'][:24]:<24}  MC ¥{row['mc_bn']:>5.1f}B  {row['ret_pct']:>+7.1f}%")
+
+
+def main():
+    engine = db.get_engine()
+    print(f"Building universe at {ENTRY}, hold to {DEADLINE}...")
+    u = build_universe(engine)
+    print(f"  {len(u)} stocks")
+    returns = compute_returns(engine, u["sec_code"].tolist())
+    names = fetch_names(engine, u["sec_code"].tolist())
+    print(f"  {len(returns)} with full price history\n")
+
+    # filters
+    small = u[(u["mc"] >= 1e9) & (u["mc"] <= 30e9)]
+    micro = u[(u["mc"] >= 1e9) & (u["mc"] <= 10e9)]
+
+    report("earnings_rocket  (≤¥30B + op_yoy > +100%)",
+           small[small["op_yoy"] > 1.0], returns, names)
+
+    report("price_momentum_top10pct  (≤¥30B, top 10% by 12m mom)",
+           small.nlargest(max(10, int(len(small) * 0.10)), "mom_12m"), returns, names)
+
+    report("high_growth  (≤¥30B + sales_yoy > +30%)",
+           small[small["sales_yoy"] > 0.30], returns, names)
+
+    report("micro_momentum  (≤¥10B + 6m_mom > +30%)",
+           micro[micro["mom_6m"] > 0.30], returns, names)
+
+    report("earnings_x_momentum  (≤¥30B + op_yoy>50% + mom_6m>10%)",
+           small[(small["op_yoy"] > 0.5) & (small["mom_6m"] > 0.1)],
+           returns, names)
+
+    report("roa_x_momentum  (≤¥30B + op_yield>20% + mom_6m>20%)",
+           small[(small["op_yield"] > 0.2) & (small["mom_6m"] > 0.2)],
+           returns, names)
+
+    # low-float proxy: bottom decile by issued shares within small cap
+    small_with_shares = small.dropna(subset=["issued_shares"])
+    n_low_float = max(20, int(len(small_with_shares) * 0.10))
+    low_float = small_with_shares.nsmallest(n_low_float, "issued_shares")
+    report("low_float_proxy  (≤¥30B, bottom 10% by issued_shares + mom_6m>0)",
+           low_float[low_float["mom_6m"] > 0], returns, names)
+
+    # control
+    report("control_random_smallcap (n=30 random)",
+           small.sample(n=min(30, len(small)), random_state=RNG_SEED), returns, names)
+
+    # also baseline_sweet_spot for shape comparison
+    sweet = u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+            & ((u["current_assets"] - u["total_liabilities"]
+                + 0.7 * u["investment_securities"].fillna(0)) / u["mc"] > 1.5)
+            & (u["per"] > 0) & (u["per"] <= 10)]
+    report("REFERENCE: baseline_sweet_spot (net-cash value)", sweet, returns, names)
+
+    print(f"\n{'='*100}")
+    print(f"TOPIX 3-year: +{TOPIX_3Y}%")
+    print(f"{'='*100}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/moonshot_robustness.py
+++ b/scripts/moonshot_robustness.py
@@ -1,0 +1,343 @@
+"""Multi-entry-date robustness test for moonshot strategies and the
+buy-and-hold version of net-cash baseline. Same 4 entry dates as
+strategy_lab_robustness.py, fixed 2-year hold per entry. Always
+buy-and-hold (no ratio<1 exit) since most moonshot strategies don't
+have a ratio.
+
+Reports per-strategy: per-entry mean/max/triple-rate/negative-rate
+plus aggregate across entries. Goal is to see whether the standout
+single-period finding (low_float_proxy mean +180% in 2022 cohort)
+survives across multiple windows.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+
+ENTRIES = [
+    date(2022, 12, 30),
+    date(2023, 6, 30),
+    date(2023, 12, 29),
+    date(2024, 6, 28),
+]
+HOLD_DAYS = 730
+DATA_END = date(2026, 4, 24)
+HAIRCUT = 0.7
+TOPIX_CODE = "13060"
+
+
+@dataclass
+class Strategy:
+    name: str
+    desc: str
+    filter_fn: Callable[[pd.DataFrame], pd.DataFrame]
+
+
+def build_universe(engine, entry: date) -> pd.DataFrame:
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities, fa.operating_income,
+                           fa.net_sales, fa.net_income, fa.issued_shares,
+                           fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) * FROM visible
+                    ORDER BY sec_code, period_end DESC
+                ),
+                ranked AS (
+                    SELECT fa2."secCode", fa2.period_end,
+                           fa2.operating_income, fa2.net_sales,
+                           LAG(fa2.operating_income) OVER w op_prev,
+                           LAG(fa2.net_sales) OVER w sales_prev
+                    FROM t_financials_annual fa2
+                    JOIN t_doc_list dl2 ON dl2."docID" = fa2.source_doc_id
+                    WHERE dl2."submitDateTime"::date <= :entry
+                    WINDOW w AS (PARTITION BY fa2."secCode" ORDER BY fa2.period_end)
+                ),
+                yoy AS (
+                    SELECT DISTINCT ON ("secCode") "secCode" sec_code, op_prev, sales_prev
+                    FROM ranked WHERE op_prev IS NOT NULL OR sales_prev IS NOT NULL
+                    ORDER BY "secCode", period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.operating_income,
+                       l.net_sales, l.net_income, l.issued_shares,
+                       y.op_prev, y.sales_prev,
+                       d_now.adj_close price_now, d_now."marketCap" mc,
+                       d_6mo.adj_close p_6mo, d_12mo.adj_close p_12mo
+                FROM latest l
+                LEFT JOIN yoy y ON y.sec_code = l.sec_code
+                JOIN t_daily_stock_perf d_now
+                  ON d_now."ShokenCode" = l.sec_code AND d_now."Date" = :entry
+                  AND d_now.adj_close IS NOT NULL AND d_now."marketCap" IS NOT NULL
+                LEFT JOIN LATERAL (
+                    SELECT adj_close FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code
+                      AND p."Date" BETWEEN :s6_start AND :s6_end
+                      AND p.adj_close IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d_6mo ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT adj_close FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code
+                      AND p."Date" BETWEEN :s12_start AND :s12_end
+                      AND p.adj_close IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d_12mo ON TRUE
+                """
+            ),
+            {
+                "entry": entry,
+                "s6_start": entry - timedelta(days=200),
+                "s6_end": entry - timedelta(days=160),
+                "s12_start": entry - timedelta(days=380),
+                "s12_end": entry - timedelta(days=350),
+            },
+        ).fetchall()
+    cols = [
+        "sec_code", "current_assets", "total_liabilities", "investment_securities",
+        "operating_income", "net_sales", "net_income", "issued_shares",
+        "op_prev", "sales_prev", "price_now", "mc", "p_6mo", "p_12mo",
+    ]
+    df = pd.DataFrame(rows, columns=cols)
+    for c in cols[1:]:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df["ratio"] = (
+        df["current_assets"] - df["total_liabilities"]
+        + HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["mc"]
+    df["per"] = df["mc"] / df["net_income"]
+    df["op_yield"] = df["operating_income"] / df["mc"]
+    df["op_yoy"] = (df["operating_income"] - df["op_prev"]) / df["op_prev"].abs()
+    df["sales_yoy"] = (df["net_sales"] - df["sales_prev"]) / df["sales_prev"]
+    df["mom_6m"] = df["price_now"] / df["p_6mo"] - 1
+    df["mom_12m"] = df["price_now"] / df["p_12mo"] - 1
+    return df
+
+
+def compute_returns_bah(engine, sec_codes, entry, deadline):
+    """Buy at entry, sell at deadline (or last available trading day before)."""
+    with engine.connect() as conn:
+        prices = pd.DataFrame(
+            conn.execute(
+                text(
+                    'SELECT "ShokenCode" sec_code, "Date" d, adj_close '
+                    'FROM t_daily_stock_perf '
+                    'WHERE "ShokenCode" = ANY(:codes) '
+                    'AND ("Date" = :s OR "Date" = ('
+                    '    SELECT MAX("Date") FROM t_daily_stock_perf WHERE "Date" <= :e '
+                    ')) AND adj_close IS NOT NULL'
+                ),
+                {"codes": sec_codes, "s": entry, "e": deadline},
+            ).fetchall(),
+            columns=["sec_code", "d", "adj_close"],
+        )
+    prices["adj_close"] = prices["adj_close"].astype(float)
+    out = {}
+    for sec_code, g in prices.groupby("sec_code"):
+        g = g.sort_values("d")
+        if len(g) < 2:
+            continue
+        ent_row = g[g["d"] == entry]
+        if ent_row.empty:
+            continue
+        ent_p = float(ent_row.iloc[0]["adj_close"])
+        ext_p = float(g.iloc[-1]["adj_close"])
+        out[sec_code] = {"return_pct": (ext_p / ent_p - 1) * 100}
+    return out
+
+
+def topix_return(engine, entry, deadline):
+    with engine.connect() as conn:
+        s = conn.execute(
+            text('SELECT adj_close FROM t_daily_stock_perf '
+                 'WHERE "ShokenCode" = :c AND "Date" >= :d ORDER BY "Date" LIMIT 1'),
+            {"c": TOPIX_CODE, "d": entry}).scalar()
+        e = conn.execute(
+            text('SELECT adj_close FROM t_daily_stock_perf '
+                 'WHERE "ShokenCode" = :c AND "Date" <= :d ORDER BY "Date" DESC LIMIT 1'),
+            {"c": TOPIX_CODE, "d": deadline}).scalar()
+    return (float(e) / float(s) - 1) * 100
+
+
+# ----- strategies -----
+
+def strategy_low_float_proxy(u):
+    """≤¥30B + bottom 10% by issued_shares + mom_6m > 0."""
+    small = u[(u["mc"] >= 1e9) & (u["mc"] <= 30e9)].dropna(subset=["issued_shares"])
+    if small.empty:
+        return small
+    n_low = max(20, int(len(small) * 0.10))
+    low = small.nsmallest(n_low, "issued_shares")
+    return low[low["mom_6m"] > 0]
+
+
+def strategy_low_float_strict(u):
+    """≤¥15B + bottom 5% by issued_shares + mom_6m > 0. More concentrated."""
+    small = u[(u["mc"] >= 1e9) & (u["mc"] <= 15e9)].dropna(subset=["issued_shares"])
+    if small.empty:
+        return small
+    n_low = max(15, int(len(small) * 0.05))
+    low = small.nsmallest(n_low, "issued_shares")
+    return low[low["mom_6m"] > 0]
+
+
+def strategy_low_float_with_value(u):
+    """Hybrid: net-cash sweet-spot (¥3-30B, ratio>1.5, PER<=10) +
+    bottom 25% by issued_shares within that subset."""
+    sweet = u[(u["mc"] >= 3e9) & (u["mc"] <= 30e9)
+            & (u["ratio"] > 1.5) & (u["per"] > 0) & (u["per"] <= 10)
+            ].dropna(subset=["issued_shares"])
+    if sweet.empty:
+        return sweet
+    n_low = max(5, int(len(sweet) * 0.25))
+    return sweet.nsmallest(n_low, "issued_shares")
+
+
+def strategy_baseline_sweet_spot_bah(u):
+    """Same baseline as strategy_lab.py but evaluated under buy-and-hold."""
+    return u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+            & (u["ratio"] > 1.5) & (u["per"] > 0) & (u["per"] <= 10)]
+
+
+def strategy_top10_by_ratio_bah(u):
+    return strategy_baseline_sweet_spot_bah(u).nlargest(10, "ratio")
+
+
+def strategy_earnings_rocket(u):
+    """≤¥30B + op_yoy > +100% (no value filter)."""
+    small = u[(u["mc"] >= 1e9) & (u["mc"] <= 30e9)]
+    return small[small["op_yoy"] > 1.0]
+
+
+STRATEGIES = [
+    Strategy("low_float_proxy",
+             "≤¥30B + bot10% issued_shares + mom_6m>0",
+             strategy_low_float_proxy),
+    Strategy("low_float_strict",
+             "≤¥15B + bot5% issued_shares + mom_6m>0",
+             strategy_low_float_strict),
+    Strategy("low_float_with_value",
+             "Sweet-spot + bot25% issued_shares (hybrid)",
+             strategy_low_float_with_value),
+    Strategy("baseline_sweet_spot_BAH",
+             "Sweet-spot, buy-and-hold (no ratio<1 exit)",
+             strategy_baseline_sweet_spot_bah),
+    Strategy("top10_by_ratio_BAH",
+             "Top 10 by ratio, buy-and-hold",
+             strategy_top10_by_ratio_bah),
+    Strategy("earnings_rocket",
+             "≤¥30B + op_yoy > +100% (no value filter)",
+             strategy_earnings_rocket),
+]
+
+
+def summarize(rets):
+    s = pd.Series(rets)
+    return {
+        "n": len(s),
+        "mean": s.mean(),
+        "median": s.median(),
+        "max": s.max(),
+        "min": s.min(),
+        "triple_pct": (s >= 200).mean() * 100,
+        "double_pct": (s >= 100).mean() * 100,
+        "neg_pct": (s < 0).mean() * 100,
+    }
+
+
+def main():
+    engine = db.get_engine()
+    results: dict[str, list[dict]] = {s.name: [] for s in STRATEGIES}
+    topix_per_entry: dict[date, float] = {}
+
+    for entry in ENTRIES:
+        deadline = min(entry + timedelta(days=HOLD_DAYS), DATA_END)
+        topix = topix_return(engine, entry, deadline)
+        topix_per_entry[entry] = topix
+        print(f"\n=== entry {entry} → {deadline} ({(deadline-entry).days}d) | TOPIX {topix:+.1f}% ===")
+        u = build_universe(engine, entry)
+        codes = u["sec_code"].tolist()
+        rets = compute_returns_bah(engine, codes, entry, deadline)
+        print(f"  universe {len(u)}, {len(rets)} priced")
+
+        for strat in STRATEGIES:
+            picks = strat.filter_fn(u)
+            r = [rets[c]["return_pct"] for c in picks["sec_code"] if c in rets]
+            if not r:
+                results[strat.name].append({"entry": entry, **summarize([0])})
+                results[strat.name][-1]["n"] = 0
+                continue
+            stats = summarize(r)
+            stats["entry"] = entry
+            stats["excess"] = stats["mean"] - topix
+            results[strat.name].append(stats)
+
+    # per-entry table
+    print("\n\n" + "=" * 130)
+    print("PER-ENTRY (mean / max / triple% / negative%)")
+    print("=" * 130)
+    header = f"{'strategy':<26}" + "".join(f" {e.isoformat():>26}" for e in ENTRIES)
+    print(header)
+    print("-" * len(header))
+    for strat in STRATEGIES:
+        line = f"{strat.name:<26}"
+        for r in results[strat.name]:
+            if r["n"] == 0:
+                line += f" {'(n=0)':>26}"
+            else:
+                line += (
+                    f" n={r['n']:>3} {r['mean']:>+5.0f}% {r['max']:>+5.0f}% "
+                    f"3x{r['triple_pct']:>3.0f} ng{r['neg_pct']:>3.0f}"
+                )
+        print(line)
+
+    # aggregate
+    print("\n" + "=" * 130)
+    print("AGGREGATE across 4 entries (each entry equal-weighted)")
+    print("=" * 130)
+    print(
+        f"{'strategy':<26}  {'avg_mean':>9} {'avg_excess':>10} {'avg_max':>9} "
+        f"{'avg_3x%':>8} {'avg_neg%':>9} {'avg_n':>6}  desc"
+    )
+    print("-" * 130)
+    for strat in STRATEGIES:
+        rs = [r for r in results[strat.name] if r["n"] > 0]
+        if not rs:
+            continue
+        avg_mean = sum(r["mean"] for r in rs) / len(rs)
+        avg_excess = sum(r["excess"] for r in rs) / len(rs)
+        avg_max = sum(r["max"] for r in rs) / len(rs)
+        avg_3x = sum(r["triple_pct"] for r in rs) / len(rs)
+        avg_neg = sum(r["neg_pct"] for r in rs) / len(rs)
+        avg_n = sum(r["n"] for r in rs) / len(rs)
+        print(
+            f"{strat.name:<26}  {avg_mean:>+8.1f}% {avg_excess:>+9.1f}% {avg_max:>+8.0f}% "
+            f"{avg_3x:>7.0f}% {avg_neg:>8.0f}% {avg_n:>6.1f}  {strat.desc}"
+        )
+    print(f"\nAvg TOPIX: {sum(topix_per_entry.values())/len(topix_per_entry):+.1f}% "
+          f"({HOLD_DAYS}d hold capped at {DATA_END})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/strategy_distribution.py
+++ b/scripts/strategy_distribution.py
@@ -1,0 +1,245 @@
+"""Per-stock 3-year return distributions for the two robust winners
+from the strategy lab: sales_growth and top10_by_ratio.
+
+Same setup as strategy_lab.py (entry 2022-12-30, exit on ratio<1 OR
+deadline 2025-12-30, $-equal-weight). Goal is to see whether returns
+are fat-right-tailed (a few moonshots) or compressed.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+
+ENTRY_DATE = date(2022, 12, 30)
+EXIT_DEADLINE = date(2025, 12, 30)
+HAIRCUT = 0.7
+EXIT_RATIO = 1.0
+TOPIX_3Y_RETURN = 81.2
+
+
+def build_universe(engine):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities, fa.operating_income,
+                           fa.net_sales, fa.net_income, fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) * FROM visible
+                    ORDER BY sec_code, period_end DESC
+                ),
+                ranked AS (
+                    SELECT fa2."secCode", fa2.period_end, fa2.net_sales,
+                           LAG(fa2.net_sales) OVER w sales_prev
+                    FROM t_financials_annual fa2
+                    JOIN t_doc_list dl2 ON dl2."docID" = fa2.source_doc_id
+                    WHERE dl2."submitDateTime"::date <= :entry
+                    WINDOW w AS (PARTITION BY fa2."secCode" ORDER BY fa2.period_end)
+                ),
+                yoy AS (
+                    SELECT DISTINCT ON ("secCode") "secCode" sec_code, sales_prev
+                    FROM ranked WHERE sales_prev IS NOT NULL
+                    ORDER BY "secCode", period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.operating_income,
+                       l.net_sales, l.net_income, y.sales_prev,
+                       d_now.adj_close price_now, d_now."marketCap" mc
+                FROM latest l
+                LEFT JOIN yoy y ON y.sec_code = l.sec_code
+                JOIN t_daily_stock_perf d_now
+                  ON d_now."ShokenCode" = l.sec_code AND d_now."Date" = :entry
+                  AND d_now.adj_close IS NOT NULL AND d_now."marketCap" IS NOT NULL
+                """
+            ),
+            {"entry": ENTRY_DATE},
+        ).fetchall()
+    cols = [
+        "sec_code", "current_assets", "total_liabilities", "investment_securities",
+        "operating_income", "net_sales", "net_income", "sales_prev",
+        "price_now", "mc",
+    ]
+    df = pd.DataFrame(rows, columns=cols)
+    for c in cols[1:]:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df["ratio"] = (
+        df["current_assets"] - df["total_liabilities"]
+        + HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["mc"]
+    df["per"] = df["mc"] / df["net_income"]
+    df["sales_yoy"] = (df["net_sales"] - df["sales_prev"]) / df["sales_prev"]
+    return df
+
+
+def compute_returns(engine, sec_codes, universe):
+    with engine.connect() as conn:
+        prices = pd.DataFrame(
+            conn.execute(
+                text(
+                    'SELECT "ShokenCode" sec_code, "Date" d, adj_close, "marketCap" '
+                    'FROM t_daily_stock_perf '
+                    'WHERE "ShokenCode" = ANY(:codes) AND "Date" BETWEEN :s AND :e '
+                    'AND adj_close IS NOT NULL AND "marketCap" IS NOT NULL '
+                    'ORDER BY "ShokenCode", "Date"'
+                ),
+                {"codes": sec_codes, "s": ENTRY_DATE, "e": EXIT_DEADLINE},
+            ).fetchall(),
+            columns=["sec_code", "d", "adj_close", "market_cap"],
+        )
+    prices["adj_close"] = prices["adj_close"].astype(float)
+    prices["market_cap"] = prices["market_cap"].astype(float)
+    init = universe.set_index("sec_code")
+    init["numerator"] = (
+        init["current_assets"] - init["total_liabilities"]
+        + HAIRCUT * init["investment_securities"].fillna(0)
+    )
+    out = {}
+    for sec_code, g in prices.groupby("sec_code"):
+        if sec_code not in init.index:
+            continue
+        ent_price = float(init.loc[sec_code, "price_now"])
+        num = float(init.loc[sec_code, "numerator"])
+        g = g.sort_values("d").reset_index(drop=True)
+        exit_d, exit_p = None, None
+        for _, r in g.iterrows():
+            ratio = num / r["market_cap"] if r["market_cap"] > 0 else 0
+            if ratio < EXIT_RATIO:
+                exit_d, exit_p = r["d"], r["adj_close"]
+                break
+        if exit_d is None:
+            last = g.iloc[-1]
+            exit_d, exit_p = last["d"], last["adj_close"]
+        out[sec_code] = {
+            "exit_d": exit_d,
+            "return_pct": (exit_p / ent_price - 1) * 100,
+            "exit_reason": "ratio<1" if (num / float(g.iloc[-1]["market_cap"]) < EXIT_RATIO and exit_d != g.iloc[-1]["d"]) else "deadline",
+        }
+    return out
+
+
+def fetch_names(engine, sec_codes):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                'SELECT DISTINCT ON ("secCode") "secCode", "filerName" '
+                'FROM t_doc_list WHERE "secCode" = ANY(:codes) '
+                'ORDER BY "secCode", "submitDateTime" DESC'
+            ),
+            {"codes": list(sec_codes)},
+        ).fetchall()
+    return {c: n for c, n in rows}
+
+
+def report(name, picks, returns, names):
+    rs = []
+    for code in picks["sec_code"]:
+        if code in returns:
+            r = returns[code]
+            rs.append({
+                "code": code,
+                "name": names.get(code, ""),
+                "ratio": picks.set_index("sec_code").loc[code, "ratio"],
+                "per": picks.set_index("sec_code").loc[code, "per"],
+                "mc_bn": picks.set_index("sec_code").loc[code, "mc"] / 1e9,
+                "ret_pct": r["return_pct"],
+                "exit_d": r["exit_d"],
+            })
+    df = pd.DataFrame(rs).sort_values("ret_pct", ascending=False).reset_index(drop=True)
+
+    print(f"\n{'='*100}")
+    print(f"{name}  —  n={len(df)}")
+    print("=" * 100)
+
+    s = df["ret_pct"]
+    print(f"\nDistribution stats:")
+    print(f"  mean:   {s.mean():+7.1f}%")
+    print(f"  median: {s.median():+7.1f}%")
+    print(f"  stdev:  {s.std():>7.1f}%")
+    print(f"  min:    {s.min():+7.1f}%")
+    print(f"  max:    {s.max():+7.1f}%")
+    print(f"  P10:    {s.quantile(0.10):+7.1f}%")
+    print(f"  P25:    {s.quantile(0.25):+7.1f}%")
+    print(f"  P75:    {s.quantile(0.75):+7.1f}%")
+    print(f"  P90:    {s.quantile(0.90):+7.1f}%")
+    print(f"  skew:   {s.skew():>7.2f}  (positive = fat right tail)")
+
+    print(f"\nReturn buckets:")
+    buckets = [
+        ("losses",        s < 0),
+        ("0-25%",         (s >= 0) & (s < 25)),
+        ("25-50%",        (s >= 25) & (s < 50)),
+        ("50-100%",       (s >= 50) & (s < 100)),
+        ("100-200%",      (s >= 100) & (s < 200)),
+        (">=200%",        s >= 200),
+    ]
+    for label, mask in buckets:
+        n = mask.sum()
+        pct = n / len(df) * 100 if len(df) else 0
+        bar = "█" * int(pct / 2)
+        print(f"  {label:>10}: n={n:>3} ({pct:>4.0f}%) {bar}")
+
+    n_beat_topix = (s > TOPIX_3Y_RETURN).sum()
+    n_doubled = (s >= 100).sum()
+    n_negative = (s < 0).sum()
+    print(f"\n  beat TOPIX (+{TOPIX_3Y_RETURN:.0f}%): {n_beat_topix}/{len(df)} ({n_beat_topix/len(df)*100:.0f}%)")
+    print(f"  doubled (>=100%):    {n_doubled}/{len(df)} ({n_doubled/len(df)*100:.0f}%)")
+    print(f"  negative:            {n_negative}/{len(df)} ({n_negative/len(df)*100:.0f}%)")
+
+    print(f"\nFull list (sorted by return):")
+    print(f"  {'rank':>4}  {'code':<6}  {'name':<24}  {'ratio':>5}  {'PER':>5}  {'MC ¥B':>6}  {'return':>8}")
+    for i, row in df.iterrows():
+        print(
+            f"  {i+1:>4}  {row['code']:<6}  {row['name'][:24]:<24}  "
+            f"{row['ratio']:>5.2f}  {row['per']:>5.1f}  {row['mc_bn']:>6.1f}  {row['ret_pct']:>+7.1f}%"
+        )
+
+
+def strategy_top10_by_ratio(u):
+    s = u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+        & (u["ratio"] > 1.5) & (u["per"] > 0) & (u["per"] <= 10)]
+    return s.nlargest(10, "ratio")
+
+
+def strategy_sales_growth(u):
+    s = u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+        & (u["ratio"] > 1.5) & (u["per"] > 0) & (u["per"] <= 10)]
+    return s[s["sales_yoy"] > 0.05]
+
+
+def main():
+    engine = db.get_engine()
+    print(f"Building universe at {ENTRY_DATE}, exit by {EXIT_DEADLINE}...")
+    u = build_universe(engine)
+    print(f"  {len(u)} stocks in raw universe")
+    returns = compute_returns(engine, u["sec_code"].tolist(), u)
+    names = fetch_names(engine, u["sec_code"].tolist())
+
+    report("top10_by_ratio (concentrated, sweet-spot top 10 by ratio)",
+           strategy_top10_by_ratio(u), returns, names)
+    report("sales_growth (sweet-spot + sales_yoy > 5%)",
+           strategy_sales_growth(u), returns, names)
+
+    print(f"\n{'='*100}")
+    print(f"Reference: TOPIX 3-yr return = +{TOPIX_3Y_RETURN}%")
+    print(f"{'='*100}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/strategy_lab.py
+++ b/scripts/strategy_lab.py
@@ -1,0 +1,343 @@
+"""Battery of strategy variants tested on the same 3-year window
+(entry 2022-12-30, exit on ratio<1 or 2025-12-30 deadline).
+
+Each strategy is a function that filters a pre-computed universe of
+stocks into a sub-universe of "picks." The lab runs all of them on
+the same data, applies the same exit rule, and reports mean/median
+returns + hit rate vs TOPIX (+81% benchmark).
+
+The point: which combinations of value / quality / momentum signals
+genuinely beat the market when applied uniformly over a 3-year hold?
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+
+ENTRY_DATE = date(2022, 12, 30)
+EXIT_DEADLINE = date(2025, 12, 30)
+HAIRCUT = 0.7
+EXIT_RATIO = 1.0
+TOPIX_3Y_RETURN = 81.2  # measured from 13060 over the window
+
+
+@dataclass
+class Strategy:
+    name: str
+    desc: str
+    filter_fn: Callable[[pd.DataFrame], pd.DataFrame]
+
+
+# ------------- universe build (entry-time snapshot of all stocks) -------------
+
+def build_universe(engine) -> pd.DataFrame:
+    """One row per stock with all entry-time fundamentals + market cap +
+    derived signals. Doesn't apply any filters except 'has data'."""
+    print(f"Building universe at {ENTRY_DATE}...")
+
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" AS sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities, fa.total_assets,
+                           fa.operating_income, fa.net_sales, fa.net_income,
+                           fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) *
+                    FROM visible ORDER BY sec_code, period_end DESC
+                ),
+                ranked AS (
+                    SELECT fa2."secCode", fa2.period_end, fa2.operating_income,
+                           fa2.net_sales, fa2.current_assets,
+                           LAG(fa2.operating_income) OVER w op_prev,
+                           LAG(fa2.net_sales) OVER w sales_prev,
+                           LAG(fa2.current_assets) OVER w ca_prev
+                    FROM t_financials_annual fa2
+                    JOIN t_doc_list dl2 ON dl2."docID" = fa2.source_doc_id
+                    WHERE dl2."submitDateTime"::date <= :entry
+                    WINDOW w AS (PARTITION BY fa2."secCode" ORDER BY fa2.period_end)
+                ),
+                yoy AS (
+                    SELECT DISTINCT ON ("secCode") "secCode" AS sec_code,
+                           op_prev, sales_prev, ca_prev
+                    FROM ranked WHERE op_prev IS NOT NULL OR sales_prev IS NOT NULL
+                    ORDER BY "secCode", period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.total_assets,
+                       l.operating_income, l.net_sales, l.net_income,
+                       y.op_prev, y.sales_prev, y.ca_prev,
+                       d_now.adj_close AS price_now,
+                       d_now."marketCap" AS mc,
+                       d_6mo.adj_close AS price_6mo,
+                       d_12mo.adj_close AS price_12mo
+                FROM latest l
+                LEFT JOIN yoy y ON y.sec_code = l.sec_code
+                JOIN t_daily_stock_perf d_now
+                  ON d_now."ShokenCode" = l.sec_code AND d_now."Date" = :entry
+                  AND d_now.adj_close IS NOT NULL AND d_now."marketCap" IS NOT NULL
+                LEFT JOIN LATERAL (
+                    SELECT adj_close FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code
+                      AND p."Date" BETWEEN :six_mo_start AND :six_mo_end
+                      AND p.adj_close IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d_6mo ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT adj_close FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code
+                      AND p."Date" BETWEEN :twelve_mo_start AND :twelve_mo_end
+                      AND p.adj_close IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d_12mo ON TRUE
+                """
+            ),
+            {
+                "entry": ENTRY_DATE,
+                "six_mo_start": ENTRY_DATE - timedelta(days=200),
+                "six_mo_end": ENTRY_DATE - timedelta(days=160),
+                "twelve_mo_start": ENTRY_DATE - timedelta(days=380),
+                "twelve_mo_end": ENTRY_DATE - timedelta(days=350),
+            },
+        ).fetchall()
+
+    cols = [
+        "sec_code", "current_assets", "total_liabilities", "investment_securities",
+        "total_assets", "operating_income", "net_sales", "net_income",
+        "op_prev", "sales_prev", "ca_prev",
+        "price_now", "mc", "price_6mo", "price_12mo",
+    ]
+    df = pd.DataFrame(rows, columns=cols)
+    for c in cols[1:]:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+
+    # Derived signals
+    df["ratio"] = (
+        df["current_assets"] - df["total_liabilities"]
+        + HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["mc"]
+    df["per"] = df["mc"] / df["net_income"]
+    df["op_yield"] = df["operating_income"] / df["mc"]
+    df["op_margin"] = df["operating_income"] / df["net_sales"]
+    df["op_yoy"] = (df["operating_income"] - df["op_prev"]) / df["op_prev"].abs()
+    df["sales_yoy"] = (df["net_sales"] - df["sales_prev"]) / df["sales_prev"]
+    df["assets_yoy"] = (df["current_assets"] - df["ca_prev"]) / df["ca_prev"]
+    df["mom_6m"] = df["price_now"] / df["price_6mo"] - 1
+    df["mom_12m"] = df["price_now"] / df["price_12mo"] - 1
+    df["mc_bn"] = df["mc"] / 1e9
+
+    print(f"  {len(df)} stocks in raw universe")
+    return df
+
+
+# ------------- compute returns once for the universe -------------
+
+def compute_returns(engine, sec_codes: list[str], universe: pd.DataFrame) -> dict[str, dict]:
+    """Walk forward day-by-day for each stock; exit at ratio<1 (using
+    static entry-numerator vs daily market cap) or at deadline."""
+    with engine.connect() as conn:
+        prices = pd.DataFrame(
+            conn.execute(
+                text(
+                    'SELECT "ShokenCode" sec_code, "Date" d, adj_close, "marketCap" '
+                    'FROM t_daily_stock_perf '
+                    'WHERE "ShokenCode" = ANY(:codes) AND "Date" BETWEEN :s AND :e '
+                    'AND adj_close IS NOT NULL AND "marketCap" IS NOT NULL '
+                    'ORDER BY "ShokenCode", "Date"'
+                ),
+                {"codes": sec_codes, "s": ENTRY_DATE, "e": EXIT_DEADLINE},
+            ).fetchall(),
+            columns=["sec_code", "d", "adj_close", "market_cap"],
+        )
+    prices["adj_close"] = prices["adj_close"].astype(float)
+    prices["market_cap"] = prices["market_cap"].astype(float)
+
+    init = universe.set_index("sec_code")
+    init["numerator"] = (
+        init["current_assets"] - init["total_liabilities"]
+        + HAIRCUT * init["investment_securities"].fillna(0)
+    )
+
+    out: dict[str, dict] = {}
+    for sec_code, g in prices.groupby("sec_code"):
+        if sec_code not in init.index:
+            continue
+        ent_price = float(init.loc[sec_code, "price_now"])
+        num = float(init.loc[sec_code, "numerator"])
+        g = g.sort_values("d").reset_index(drop=True)
+        exit_d, exit_p = None, None
+        for _, r in g.iterrows():
+            ratio = num / r["market_cap"] if r["market_cap"] > 0 else 0
+            if ratio < EXIT_RATIO:
+                exit_d, exit_p = r["d"], r["adj_close"]
+                break
+        if exit_d is None:
+            last = g.iloc[-1]
+            exit_d, exit_p = last["d"], last["adj_close"]
+        out[sec_code] = {
+            "exit_d": exit_d,
+            "exit_p": exit_p,
+            "return_pct": (exit_p / ent_price - 1) * 100,
+            "days_held": (exit_d - ENTRY_DATE).days,
+        }
+    return out
+
+
+# ------------- strategies -------------
+
+def strategy_baseline_sweet_spot(u: pd.DataFrame) -> pd.DataFrame:
+    return u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+            & (u["ratio"] > 1.5) & (u["per"] > 0) & (u["per"] <= 10)]
+
+
+def strategy_top10_by_ratio(u: pd.DataFrame) -> pd.DataFrame:
+    """Concentrated: top 10 by ratio within sweet-spot."""
+    return strategy_baseline_sweet_spot(u).nlargest(10, "ratio")
+
+
+def strategy_value_momentum(u: pd.DataFrame) -> pd.DataFrame:
+    """Sweet-spot + positive 6m price momentum."""
+    s = strategy_baseline_sweet_spot(u)
+    return s[s["mom_6m"] > 0]
+
+
+def strategy_value_quality(u: pd.DataFrame) -> pd.DataFrame:
+    """Sweet-spot + op margin > 10% (real profitability)."""
+    s = strategy_baseline_sweet_spot(u)
+    return s[s["op_margin"] > 0.10]
+
+
+def strategy_sales_growth(u: pd.DataFrame) -> pd.DataFrame:
+    """Sweet-spot + sales accelerating > 5% YoY."""
+    s = strategy_baseline_sweet_spot(u)
+    return s[s["sales_yoy"] > 0.05]
+
+
+def strategy_cash_compounders(u: pd.DataFrame) -> pd.DataFrame:
+    """Net-cash growing organically: ratio>1 + current_assets up YoY +
+    sales up YoY (cash piling up while business expands)."""
+    s = u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+         & (u["ratio"] > 1.0) & (u["assets_yoy"] > 0.05) & (u["sales_yoy"] > 0)
+         & (u["per"] > 0) & (u["per"] <= 15)]
+    return s
+
+
+def strategy_qmom(u: pd.DataFrame) -> pd.DataFrame:
+    """Quality + Momentum, no value filter. op_yield > 10%, mom_6m > 10%."""
+    return u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+           & (u["op_yield"] > 0.10) & (u["mom_6m"] > 0.10)
+           & (u["per"] > 0) & (u["per"] <= 15)]
+
+
+def strategy_reversal(u: pd.DataFrame) -> pd.DataFrame:
+    """Big 12m drawdown but business holding up: ratio>1, mom_12m<-20%,
+    sales_yoy > -5%, op_margin > 0."""
+    return u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+           & (u["ratio"] > 1.0) & (u["mom_12m"] < -0.20)
+           & (u["sales_yoy"] > -0.05) & (u["op_margin"] > 0)]
+
+
+def strategy_z_composite(u: pd.DataFrame) -> pd.DataFrame:
+    """Top decile by z-score of (ratio + op_yield + sales_yoy + mom_6m).
+    Multi-factor blend within sweet-spot universe."""
+    s = strategy_baseline_sweet_spot(u).copy()
+    if s.empty:
+        return s
+    for col in ("ratio", "op_yield", "sales_yoy", "mom_6m"):
+        s[f"z_{col}"] = (s[col] - s[col].mean()) / s[col].std()
+    s["z_total"] = s[["z_ratio", "z_op_yield", "z_sales_yoy", "z_mom_6m"]].sum(axis=1)
+    return s.nlargest(max(10, int(len(s) * 0.20)), "z_total")
+
+
+def strategy_low_per_top10(u: pd.DataFrame) -> pd.DataFrame:
+    """Top 10 lowest PER within net-cash + cap range. Pure cheapness."""
+    s = u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+        & (u["ratio"] > 1.0) & (u["per"] > 0) & (u["per"] <= 5)]
+    return s.nsmallest(10, "per")
+
+
+STRATEGIES = [
+    Strategy("baseline_sweet_spot",
+             "¥3-50B + ratio>1.5 + PER≤10",
+             strategy_baseline_sweet_spot),
+    Strategy("top10_by_ratio",
+             "Top 10 by ratio within sweet-spot (concentrated)",
+             strategy_top10_by_ratio),
+    Strategy("value_momentum",
+             "Sweet-spot + 6m_mom > 0 (price catalyst)",
+             strategy_value_momentum),
+    Strategy("value_quality",
+             "Sweet-spot + op_margin > 10% (real profitability)",
+             strategy_value_quality),
+    Strategy("sales_growth",
+             "Sweet-spot + sales_yoy > 5% (top-line accelerating)",
+             strategy_sales_growth),
+    Strategy("cash_compounders",
+             "ratio>1 + current_assets growing + sales growing",
+             strategy_cash_compounders),
+    Strategy("qmom",
+             "Quality+Momentum (no value): op_yield>10%, mom_6m>10%",
+             strategy_qmom),
+    Strategy("reversal",
+             "Down 20%+ in 12m but biz OK: mean reversion candidates",
+             strategy_reversal),
+    Strategy("z_composite",
+             "Top 20% by composite z-score (ratio+op_yld+sales_yoy+mom)",
+             strategy_z_composite),
+    Strategy("low_per_top10",
+             "Top 10 lowest PER (≤5) with ratio>1",
+             strategy_low_per_top10),
+]
+
+
+def main():
+    engine = db.get_engine()
+    u = build_universe(engine)
+    sec_codes = u["sec_code"].tolist()
+    returns = compute_returns(engine, sec_codes, u)
+    print(f"  {len(returns)} stocks have full price history\n")
+
+    print(f"{'strategy':<26}  {'n':>4}  {'mean':>7} {'median':>7} {'>TOPIX':>7} {'>0%':>5}  description")
+    print("-" * 130)
+    for strat in STRATEGIES:
+        picks = strat.filter_fn(u)
+        rets = []
+        for code in picks["sec_code"]:
+            if code in returns:
+                rets.append(returns[code]["return_pct"])
+        if not rets:
+            print(f"{strat.name:<26}  {0:>4}  {'-':>7} {'-':>7} {'-':>7} {'-':>5}  {strat.desc}")
+            continue
+        s = pd.Series(rets)
+        beat_topix = (s > TOPIX_3Y_RETURN).mean() * 100
+        positive = (s > 0).mean() * 100
+        print(
+            f"{strat.name:<26}  {len(rets):>4}  {s.mean():>+6.1f}% {s.median():>+6.1f}% "
+            f"{beat_topix:>5.0f}% {positive:>4.0f}%  {strat.desc}"
+        )
+
+    print()
+    print(f"TOPIX 3-year (2022-12-30 → 2025-12-30): +{TOPIX_3Y_RETURN}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/strategy_lab_robustness.py
+++ b/scripts/strategy_lab_robustness.py
@@ -1,0 +1,355 @@
+"""Multi-entry-date robustness check on the 10 strategies from
+strategy_lab.py. The original lab result (top10_by_ratio +87.7%) was
+from a single entry date — this script asks: does it survive when we
+move the entry date around?
+
+Setup: 4 entry dates spaced ~6 months apart, fixed 2-year hold each
+(min(entry+730d, today)). Each entry gets its own TOPIX benchmark
+computed over the same window so excess-return is honest.
+
+Reports per-strategy: per-entry returns, aggregate mean across entries,
+hit rate vs TOPIX, and how often the strategy beats TOPIX in any
+single window.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+
+ENTRIES = [
+    date(2022, 12, 30),
+    date(2023, 6, 30),
+    date(2023, 12, 29),
+    date(2024, 6, 28),
+]
+HOLD_DAYS = 730
+DATA_END = date(2026, 4, 24)
+HAIRCUT = 0.7
+EXIT_RATIO = 1.0
+TOPIX_CODE = "13060"
+
+
+@dataclass
+class Strategy:
+    name: str
+    desc: str
+    filter_fn: Callable[[pd.DataFrame], pd.DataFrame]
+
+
+def build_universe(engine, entry: date) -> pd.DataFrame:
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" AS sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities, fa.total_assets,
+                           fa.operating_income, fa.net_sales, fa.net_income,
+                           fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= :entry
+                      AND fa.current_assets IS NOT NULL
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) *
+                    FROM visible ORDER BY sec_code, period_end DESC
+                ),
+                ranked AS (
+                    SELECT fa2."secCode", fa2.period_end, fa2.operating_income,
+                           fa2.net_sales, fa2.current_assets,
+                           LAG(fa2.operating_income) OVER w op_prev,
+                           LAG(fa2.net_sales) OVER w sales_prev,
+                           LAG(fa2.current_assets) OVER w ca_prev
+                    FROM t_financials_annual fa2
+                    JOIN t_doc_list dl2 ON dl2."docID" = fa2.source_doc_id
+                    WHERE dl2."submitDateTime"::date <= :entry
+                    WINDOW w AS (PARTITION BY fa2."secCode" ORDER BY fa2.period_end)
+                ),
+                yoy AS (
+                    SELECT DISTINCT ON ("secCode") "secCode" AS sec_code,
+                           op_prev, sales_prev, ca_prev
+                    FROM ranked WHERE op_prev IS NOT NULL OR sales_prev IS NOT NULL
+                    ORDER BY "secCode", period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.total_assets,
+                       l.operating_income, l.net_sales, l.net_income,
+                       y.op_prev, y.sales_prev, y.ca_prev,
+                       d_now.adj_close AS price_now,
+                       d_now."marketCap" AS mc,
+                       d_6mo.adj_close AS price_6mo,
+                       d_12mo.adj_close AS price_12mo
+                FROM latest l
+                LEFT JOIN yoy y ON y.sec_code = l.sec_code
+                JOIN t_daily_stock_perf d_now
+                  ON d_now."ShokenCode" = l.sec_code AND d_now."Date" = :entry
+                  AND d_now.adj_close IS NOT NULL AND d_now."marketCap" IS NOT NULL
+                LEFT JOIN LATERAL (
+                    SELECT adj_close FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code
+                      AND p."Date" BETWEEN :six_mo_start AND :six_mo_end
+                      AND p.adj_close IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d_6mo ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT adj_close FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code
+                      AND p."Date" BETWEEN :twelve_mo_start AND :twelve_mo_end
+                      AND p.adj_close IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d_12mo ON TRUE
+                """
+            ),
+            {
+                "entry": entry,
+                "six_mo_start": entry - timedelta(days=200),
+                "six_mo_end": entry - timedelta(days=160),
+                "twelve_mo_start": entry - timedelta(days=380),
+                "twelve_mo_end": entry - timedelta(days=350),
+            },
+        ).fetchall()
+
+    cols = [
+        "sec_code", "current_assets", "total_liabilities", "investment_securities",
+        "total_assets", "operating_income", "net_sales", "net_income",
+        "op_prev", "sales_prev", "ca_prev",
+        "price_now", "mc", "price_6mo", "price_12mo",
+    ]
+    df = pd.DataFrame(rows, columns=cols)
+    for c in cols[1:]:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df["ratio"] = (
+        df["current_assets"] - df["total_liabilities"]
+        + HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["mc"]
+    df["per"] = df["mc"] / df["net_income"]
+    df["op_yield"] = df["operating_income"] / df["mc"]
+    df["op_margin"] = df["operating_income"] / df["net_sales"]
+    df["op_yoy"] = (df["operating_income"] - df["op_prev"]) / df["op_prev"].abs()
+    df["sales_yoy"] = (df["net_sales"] - df["sales_prev"]) / df["sales_prev"]
+    df["assets_yoy"] = (df["current_assets"] - df["ca_prev"]) / df["ca_prev"]
+    df["mom_6m"] = df["price_now"] / df["price_6mo"] - 1
+    df["mom_12m"] = df["price_now"] / df["price_12mo"] - 1
+    df["mc_bn"] = df["mc"] / 1e9
+    return df
+
+
+def compute_returns(
+    engine, sec_codes: list[str], universe: pd.DataFrame, entry: date, deadline: date
+) -> dict[str, dict]:
+    with engine.connect() as conn:
+        prices = pd.DataFrame(
+            conn.execute(
+                text(
+                    'SELECT "ShokenCode" sec_code, "Date" d, adj_close, "marketCap" '
+                    'FROM t_daily_stock_perf '
+                    'WHERE "ShokenCode" = ANY(:codes) AND "Date" BETWEEN :s AND :e '
+                    'AND adj_close IS NOT NULL AND "marketCap" IS NOT NULL '
+                    'ORDER BY "ShokenCode", "Date"'
+                ),
+                {"codes": sec_codes, "s": entry, "e": deadline},
+            ).fetchall(),
+            columns=["sec_code", "d", "adj_close", "market_cap"],
+        )
+    prices["adj_close"] = prices["adj_close"].astype(float)
+    prices["market_cap"] = prices["market_cap"].astype(float)
+
+    init = universe.set_index("sec_code")
+    init["numerator"] = (
+        init["current_assets"] - init["total_liabilities"]
+        + HAIRCUT * init["investment_securities"].fillna(0)
+    )
+
+    out: dict[str, dict] = {}
+    for sec_code, g in prices.groupby("sec_code"):
+        if sec_code not in init.index:
+            continue
+        ent_price = float(init.loc[sec_code, "price_now"])
+        num = float(init.loc[sec_code, "numerator"])
+        g = g.sort_values("d").reset_index(drop=True)
+        exit_d, exit_p = None, None
+        for _, r in g.iterrows():
+            ratio = num / r["market_cap"] if r["market_cap"] > 0 else 0
+            if ratio < EXIT_RATIO:
+                exit_d, exit_p = r["d"], r["adj_close"]
+                break
+        if exit_d is None:
+            last = g.iloc[-1]
+            exit_d, exit_p = last["d"], last["adj_close"]
+        out[sec_code] = {"return_pct": (exit_p / ent_price - 1) * 100}
+    return out
+
+
+def topix_return(engine, entry: date, deadline: date) -> float:
+    with engine.connect() as conn:
+        s = conn.execute(
+            text(
+                'SELECT adj_close FROM t_daily_stock_perf '
+                'WHERE "ShokenCode" = :c AND "Date" >= :d '
+                'ORDER BY "Date" LIMIT 1'
+            ),
+            {"c": TOPIX_CODE, "d": entry},
+        ).scalar()
+        e = conn.execute(
+            text(
+                'SELECT adj_close FROM t_daily_stock_perf '
+                'WHERE "ShokenCode" = :c AND "Date" <= :d '
+                'ORDER BY "Date" DESC LIMIT 1'
+            ),
+            {"c": TOPIX_CODE, "d": deadline},
+        ).scalar()
+    return (float(e) / float(s) - 1) * 100
+
+
+# --- strategies (copied verbatim from strategy_lab.py) ---
+
+def strategy_baseline_sweet_spot(u):
+    return u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+            & (u["ratio"] > 1.5) & (u["per"] > 0) & (u["per"] <= 10)]
+
+def strategy_top10_by_ratio(u):
+    return strategy_baseline_sweet_spot(u).nlargest(10, "ratio")
+
+def strategy_value_momentum(u):
+    s = strategy_baseline_sweet_spot(u)
+    return s[s["mom_6m"] > 0]
+
+def strategy_value_quality(u):
+    s = strategy_baseline_sweet_spot(u)
+    return s[s["op_margin"] > 0.10]
+
+def strategy_sales_growth(u):
+    s = strategy_baseline_sweet_spot(u)
+    return s[s["sales_yoy"] > 0.05]
+
+def strategy_cash_compounders(u):
+    return u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+           & (u["ratio"] > 1.0) & (u["assets_yoy"] > 0.05) & (u["sales_yoy"] > 0)
+           & (u["per"] > 0) & (u["per"] <= 15)]
+
+def strategy_qmom(u):
+    return u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+           & (u["op_yield"] > 0.10) & (u["mom_6m"] > 0.10)
+           & (u["per"] > 0) & (u["per"] <= 15)]
+
+def strategy_reversal(u):
+    return u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+           & (u["ratio"] > 1.0) & (u["mom_12m"] < -0.20)
+           & (u["sales_yoy"] > -0.05) & (u["op_margin"] > 0)]
+
+def strategy_z_composite(u):
+    s = strategy_baseline_sweet_spot(u).copy()
+    if s.empty:
+        return s
+    for col in ("ratio", "op_yield", "sales_yoy", "mom_6m"):
+        s[f"z_{col}"] = (s[col] - s[col].mean()) / s[col].std()
+    s["z_total"] = s[["z_ratio", "z_op_yield", "z_sales_yoy", "z_mom_6m"]].sum(axis=1)
+    return s.nlargest(max(10, int(len(s) * 0.20)), "z_total")
+
+def strategy_low_per_top10(u):
+    s = u[(u["mc"] >= 3e9) & (u["mc"] <= 50e9)
+        & (u["ratio"] > 1.0) & (u["per"] > 0) & (u["per"] <= 5)]
+    return s.nsmallest(10, "per")
+
+
+STRATEGIES = [
+    Strategy("baseline_sweet_spot", "¥3-50B + ratio>1.5 + PER≤10", strategy_baseline_sweet_spot),
+    Strategy("top10_by_ratio", "Top 10 by ratio (concentrated)", strategy_top10_by_ratio),
+    Strategy("value_momentum", "Sweet-spot + 6m_mom > 0", strategy_value_momentum),
+    Strategy("value_quality", "Sweet-spot + op_margin > 10%", strategy_value_quality),
+    Strategy("sales_growth", "Sweet-spot + sales_yoy > 5%", strategy_sales_growth),
+    Strategy("cash_compounders", "ratio>1 + assets+sales growing", strategy_cash_compounders),
+    Strategy("qmom", "Quality+Momentum (no value)", strategy_qmom),
+    Strategy("reversal", "12m drawdown but biz OK", strategy_reversal),
+    Strategy("z_composite", "Top 20% by z-score blend", strategy_z_composite),
+    Strategy("low_per_top10", "Top 10 lowest PER ≤5", strategy_low_per_top10),
+]
+
+
+def main():
+    engine = db.get_engine()
+    # rows: strategy x entry → (n, mean_return, excess vs topix)
+    results: dict[str, list[dict]] = {s.name: [] for s in STRATEGIES}
+    topix_per_entry: dict[date, float] = {}
+
+    for entry in ENTRIES:
+        deadline = min(entry + timedelta(days=HOLD_DAYS), DATA_END)
+        topix = topix_return(engine, entry, deadline)
+        topix_per_entry[entry] = topix
+        print(f"\n=== entry {entry} → {deadline} ({(deadline-entry).days}d hold) | TOPIX {topix:+.1f}% ===")
+        u = build_universe(engine, entry)
+        codes = u["sec_code"].tolist()
+        rets = compute_returns(engine, codes, u, entry, deadline)
+        print(f"  universe: {len(u)} stocks, {len(rets)} with full price history")
+
+        for strat in STRATEGIES:
+            picks = strat.filter_fn(u)
+            r = [rets[c]["return_pct"] for c in picks["sec_code"] if c in rets]
+            if not r:
+                results[strat.name].append({
+                    "entry": entry, "n": 0, "mean": None, "excess": None, "beat_topix": None
+                })
+                continue
+            mean = float(pd.Series(r).mean())
+            excess = mean - topix
+            beat = (pd.Series(r) > topix).mean() * 100
+            results[strat.name].append({
+                "entry": entry, "n": len(r), "mean": mean,
+                "excess": excess, "beat_topix": beat,
+            })
+
+    # per-entry x per-strategy table
+    print("\n\n" + "=" * 100)
+    print("PER-ENTRY MEAN RETURN (excess vs TOPIX in parens)")
+    print("=" * 100)
+    header = f"{'strategy':<22}" + "".join(f"  {e.isoformat():>22}" for e in ENTRIES)
+    print(header)
+    print("-" * len(header))
+    for strat in STRATEGIES:
+        line = f"{strat.name:<22}"
+        for r in results[strat.name]:
+            if r["mean"] is None:
+                line += f"  {'(n=0)':>22}"
+            else:
+                line += f"  n={r['n']:>2} {r['mean']:>+6.1f}% ({r['excess']:>+5.1f})"
+        print(line)
+    print(f"{'TOPIX':<22}" + "".join(f"  {topix_per_entry[e]:>+22.1f}%" for e in ENTRIES))
+
+    # aggregate (mean across entries, weighting all entries equally)
+    print("\n" + "=" * 100)
+    print("AGGREGATE: mean of per-entry mean returns (each entry weighted equally)")
+    print("=" * 100)
+    print(f"{'strategy':<22}  {'avg_ret':>8}  {'avg_excess':>10}  {'win_rate':>9}  {'avg_n':>6}  desc")
+    print("-" * 110)
+    for strat in STRATEGIES:
+        rs = [r for r in results[strat.name] if r["mean"] is not None]
+        if not rs:
+            continue
+        avg_ret = sum(r["mean"] for r in rs) / len(rs)
+        avg_excess = sum(r["excess"] for r in rs) / len(rs)
+        win_rate = sum(1 for r in rs if r["excess"] > 0) / len(rs) * 100
+        avg_n = sum(r["n"] for r in rs) / len(rs)
+        print(
+            f"{strat.name:<22}  {avg_ret:>+7.1f}%  {avg_excess:>+9.1f}%  "
+            f"{win_rate:>8.0f}%  {avg_n:>6.1f}  {strat.desc}"
+        )
+    avg_topix = sum(topix_per_entry.values()) / len(topix_per_entry)
+    print(f"\nAvg TOPIX across {len(ENTRIES)} entries: {avg_topix:+.1f}%")
+    print(f"Hold length: {HOLD_DAYS} days (~{HOLD_DAYS/365:.1f} yr) capped at {DATA_END}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_ibkr_positions.py
+++ b/scripts/sync_ibkr_positions.py
@@ -58,9 +58,9 @@ def main() -> int:
     print("=" * 130)
     print(
         f"  {'code':<6} {'name':<24} {'qty':>6} {'cost':>8} {'mark':>8} "
-        f"{'P&L':>9} {'ratio':>6} {'PER':>5} {'flags':>6}  status"
+        f"{'P&L':>9} {'ret%':>7} {'ratio':>6} {'PER':>5} {'flags':>6}  status"
     )
-    print("-" * 130)
+    print("-" * 138)
 
     for _, r in df.iterrows():
         flags = []
@@ -84,10 +84,15 @@ def main() -> int:
         mark_s = f"¥{r['mark_price']:.0f}" if pd.notna(r.get("mark_price")) else "?"
         pl_s = f"{r['unrealized_pl']:+,.0f}" if pd.notna(r.get("unrealized_pl")) else "?"
 
+        if pd.notna(r.get("cost_basis")) and pd.notna(r.get("mark_price")) and r["cost_basis"]:
+            ret_s = f"{(r['mark_price']/r['cost_basis']-1)*100:+.1f}%"
+        else:
+            ret_s = "?"
+
         print(
             f"  {r['symbol']:<6} {(r['description'] or '')[:24]:<24} "
             f"{r['quantity']:>6.0f} {cost_s:>8} {mark_s:>8} "
-            f"{pl_s:>9} {ratio_s:>6} {per_s:>5} {flag_s:>6}  {status}"
+            f"{pl_s:>9} {ret_s:>7} {ratio_s:>6} {per_s:>5} {flag_s:>6}  {status}"
         )
 
     # Summary by status

--- a/scripts/sync_ibkr_positions.py
+++ b/scripts/sync_ibkr_positions.py
@@ -1,0 +1,105 @@
+"""Fetch IBKR positions via Flex Web Service and show each holding's
+current screen state (ratio, Q/T flags, exit-trigger).
+
+Setup (one-time, in your IBKR account portal):
+  1. Performance & Reports → Flex Queries → Flex Web Service → Configure
+     Generate a token. Copy it to .env as IBKR_FLEX_TOKEN.
+  2. Performance & Reports → Flex Queries → Custom Flex Queries → Create
+     - Type: Activity
+     - Sections: only "Open Positions" is required for this script
+     - Default fields are fine; symbol, position, markPrice, costBasisPrice,
+       fifoPnlUnrealized, currency, isin, description are all in defaults.
+     - Save the query and copy its Query ID to .env as
+       IBKR_POSITIONS_QUERY_ID.
+
+Then run:
+  set -a && . ./.env && set +a && PYTHONPATH=src uv run python scripts/sync_ibkr_positions.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stock_screening import db
+from stock_screening.ibkr.flex_client import FlexClient
+from stock_screening.ibkr.positions import enrich_with_screen, parse_open_positions
+
+
+def main() -> int:
+    token = os.environ.get("IBKR_FLEX_TOKEN")
+    query_id = os.environ.get("IBKR_POSITIONS_QUERY_ID")
+    if not token or not query_id:
+        print("ERROR: IBKR_FLEX_TOKEN and IBKR_POSITIONS_QUERY_ID must be set in .env",
+              file=sys.stderr)
+        print("  See header docstring for setup steps.", file=sys.stderr)
+        return 2
+
+    client = FlexClient(token)
+    print(f"Fetching Flex query {query_id}...")
+    resp = client.fetch_query(query_id)
+    positions = parse_open_positions(resp.root)
+    print(f"  Got {len(positions)} open positions")
+    if not positions:
+        return 0
+
+    engine = db.get_engine()
+    df = enrich_with_screen(engine, positions)
+
+    # Pretty print
+    print()
+    print("=" * 130)
+    print("IBKR POSITIONS — joined with screen state")
+    print("=" * 130)
+    print(
+        f"  {'code':<6} {'name':<24} {'qty':>6} {'cost':>8} {'mark':>8} "
+        f"{'P&L':>9} {'ratio':>6} {'PER':>5} {'flags':>6}  status"
+    )
+    print("-" * 130)
+
+    for _, r in df.iterrows():
+        flags = []
+        if r.get("q_flag", False) is True: flags.append("Q")
+        if r.get("t_flag", False) is True: flags.append("T")
+        flag_s = "+".join(flags) or "—"
+
+        ratio_s = f"{r['ratio']:.2f}" if pd.notna(r.get("ratio")) else "  ?"
+        per_s = f"{r['per']:.1f}" if pd.notna(r.get("per")) else "  ?"
+
+        if pd.isna(r.get("ratio")):
+            status = "NO_DATA (not in screen DB — manual review)"
+        elif r["ratio"] < 1.0:
+            status = "EXIT TRIGGERED (ratio < 1.0)"
+        elif r["ratio"] < 1.5:
+            status = "WATCH (ratio in 1.0-1.5 weak cohort)"
+        else:
+            status = "HOLD (ratio > 1.5, screen still active)"
+
+        cost_s = f"¥{r['cost_basis']:.0f}" if pd.notna(r.get("cost_basis")) else "?"
+        mark_s = f"¥{r['mark_price']:.0f}" if pd.notna(r.get("mark_price")) else "?"
+        pl_s = f"{r['unrealized_pl']:+,.0f}" if pd.notna(r.get("unrealized_pl")) else "?"
+
+        print(
+            f"  {r['symbol']:<6} {(r['description'] or '')[:24]:<24} "
+            f"{r['quantity']:>6.0f} {cost_s:>8} {mark_s:>8} "
+            f"{pl_s:>9} {ratio_s:>6} {per_s:>5} {flag_s:>6}  {status}"
+        )
+
+    # Summary by status
+    print()
+    if "ratio" in df.columns:
+        n_exit = int((df["ratio"] < 1.0).sum())
+        n_watch = int(((df["ratio"] >= 1.0) & (df["ratio"] < 1.5)).sum())
+        n_hold = int((df["ratio"] >= 1.5).sum())
+        n_nodata = int(df["ratio"].isna().sum())
+        print(f"  HOLD: {n_hold}  WATCH: {n_watch}  EXIT: {n_exit}  NO_DATA: {n_nodata}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_ibkr_positions.py
+++ b/scripts/sync_ibkr_positions.py
@@ -58,9 +58,13 @@ def main() -> int:
     print("=" * 130)
     print(
         f"  {'code':<6} {'name':<24} {'qty':>6} {'cost':>8} {'mark':>8} "
-        f"{'P&L':>9} {'ret%':>7} {'ratio':>6} {'PER':>5} {'flags':>6}  status"
+        f"{'value':>11} {'P&L':>9} {'ret%':>7} {'ratio':>6} {'PER':>5} {'flags':>6}  status"
     )
-    print("-" * 138)
+    print("-" * 150)
+
+    total_value = 0.0
+    total_pl = 0.0
+    total_cost = 0.0
 
     for _, r in df.iterrows():
         flags = []
@@ -84,6 +88,18 @@ def main() -> int:
         mark_s = f"¥{r['mark_price']:.0f}" if pd.notna(r.get("mark_price")) else "?"
         pl_s = f"{r['unrealized_pl']:+,.0f}" if pd.notna(r.get("unrealized_pl")) else "?"
 
+        if pd.notna(r.get("mark_price")) and pd.notna(r.get("quantity")):
+            value = float(r["mark_price"]) * float(r["quantity"])
+            value_s = f"¥{value:>10,.0f}"
+            total_value += value
+        else:
+            value_s = "?"
+
+        if pd.notna(r.get("cost_basis")) and pd.notna(r.get("quantity")):
+            total_cost += float(r["cost_basis"]) * float(r["quantity"])
+        if pd.notna(r.get("unrealized_pl")):
+            total_pl += float(r["unrealized_pl"])
+
         if pd.notna(r.get("cost_basis")) and pd.notna(r.get("mark_price")) and r["cost_basis"]:
             ret_s = f"{(r['mark_price']/r['cost_basis']-1)*100:+.1f}%"
         else:
@@ -92,8 +108,27 @@ def main() -> int:
         print(
             f"  {r['symbol']:<6} {(r['description'] or '')[:24]:<24} "
             f"{r['quantity']:>6.0f} {cost_s:>8} {mark_s:>8} "
-            f"{pl_s:>9} {ret_s:>7} {ratio_s:>6} {per_s:>5} {flag_s:>6}  {status}"
+            f"{value_s:>11} {pl_s:>9} {ret_s:>7} {ratio_s:>6} {per_s:>5} {flag_s:>6}  {status}"
         )
+
+    # Portfolio totals
+    print("-" * 150)
+    if total_cost:
+        total_ret_pct = (total_value / total_cost - 1) * 100
+        weight_lines = []
+        for _, r in df.iterrows():
+            if pd.notna(r.get("mark_price")) and pd.notna(r.get("quantity")):
+                v = float(r["mark_price"]) * float(r["quantity"])
+                w = v / total_value * 100 if total_value else 0
+                weight_lines.append((r["symbol"], v, w))
+        print(
+            f"  TOTAL                                                              "
+            f"¥{total_value:>10,.0f} {total_pl:>+9,.0f} {total_ret_pct:>+6.1f}%"
+        )
+        print(f"\n  Position weights (by current value):")
+        for sym, v, w in sorted(weight_lines, key=lambda x: -x[1]):
+            bar = "█" * int(w / 2)
+            print(f"    {sym:<6}  ¥{v:>10,.0f}  {w:>5.1f}%  {bar}")
 
     # Summary by status
     print()

--- a/src/stock_screening/ibkr/flex_client.py
+++ b/src/stock_screening/ibkr/flex_client.py
@@ -1,0 +1,122 @@
+"""IBKR Flex Web Service client.
+
+Two-step protocol:
+  1. SendRequest with (token, query_id) → returns ReferenceCode
+  2. GetStatement with (token, ref_code) → returns the actual XML report
+
+Step 2 may return a "still generating" warning (ErrorCode 1019); the
+client polls until the report is ready or the timeout elapses.
+
+Read-only — Flex queries can only return reports the user pre-defined
+in their IBKR account portal. The token is account-scoped and revocable
+without affecting trading credentials.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from xml.etree import ElementTree as ET
+
+import requests
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+BASE = "https://gdcdyn.interactivebrokers.com/Universal/servlet"
+SEND_PATH = f"{BASE}/FlexStatementService.SendRequest"
+GET_PATH = f"{BASE}/FlexStatementService.GetStatement"
+API_VERSION = "3"
+
+# IBKR's "still generating, retry" code.
+STILL_GENERATING_CODE = "1019"
+
+logger = logging.getLogger(__name__)
+
+
+class FlexAPIError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class FlexResponse:
+    """Raw XML body of a successful GetStatement call."""
+    xml: str
+    root: ET.Element
+
+
+class FlexClient:
+    def __init__(self, token: str, *, poll_interval_s: float = 3.0,
+                 poll_timeout_s: float = 120.0):
+        self._token = token
+        self._poll_interval_s = poll_interval_s
+        self._poll_timeout_s = poll_timeout_s
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=2, min=2, max=20),
+        retry=retry_if_exception_type(requests.RequestException),
+        reraise=True,
+    )
+    def _send(self, query_id: str) -> str:
+        params = {"t": self._token, "q": query_id, "v": API_VERSION}
+        r = requests.get(SEND_PATH, params=params, timeout=30)
+        r.raise_for_status()
+        root = ET.fromstring(r.text)
+        status = (root.findtext("Status") or "").strip()
+        if status != "Success":
+            err_code = root.findtext("ErrorCode") or "?"
+            err_msg = root.findtext("ErrorMessage") or "(no message)"
+            raise FlexAPIError(
+                f"SendRequest returned {status}: {err_code} {err_msg}"
+            )
+        ref = root.findtext("ReferenceCode")
+        if not ref:
+            raise FlexAPIError(f"SendRequest missing ReferenceCode: {r.text[:200]}")
+        return ref
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=2, min=2, max=20),
+        retry=retry_if_exception_type(requests.RequestException),
+        reraise=True,
+    )
+    def _get(self, ref_code: str) -> requests.Response:
+        params = {"t": self._token, "q": ref_code, "v": API_VERSION}
+        r = requests.get(GET_PATH, params=params, timeout=60)
+        r.raise_for_status()
+        return r
+
+    def fetch_query(self, query_id: str) -> FlexResponse:
+        """End-to-end: send + poll + return parsed XML root."""
+        ref = self._send(query_id)
+        logger.info("flex query %s submitted, ref=%s", query_id, ref)
+        deadline = time.monotonic() + self._poll_timeout_s
+        while time.monotonic() < deadline:
+            r = self._get(ref)
+            # The "still generating" response is itself a small
+            # FlexStatementResponse with Status=Warn. The success response
+            # is the full FlexQueryResponse with the actual data.
+            try:
+                root = ET.fromstring(r.text)
+            except ET.ParseError as e:
+                raise FlexAPIError(f"GetStatement returned non-XML: {e}: {r.text[:200]}")
+            if root.tag == "FlexStatementResponse":
+                status = (root.findtext("Status") or "").strip()
+                err_code = root.findtext("ErrorCode") or "?"
+                err_msg = root.findtext("ErrorMessage") or ""
+                if err_code == STILL_GENERATING_CODE:
+                    logger.debug("statement still generating, sleeping %ss", self._poll_interval_s)
+                    time.sleep(self._poll_interval_s)
+                    continue
+                raise FlexAPIError(
+                    f"GetStatement returned {status}: {err_code} {err_msg}"
+                )
+            return FlexResponse(xml=r.text, root=root)
+        raise FlexAPIError(
+            f"GetStatement timed out after {self._poll_timeout_s}s waiting for ref {ref}"
+        )

--- a/src/stock_screening/ibkr/positions.py
+++ b/src/stock_screening/ibkr/positions.py
@@ -1,0 +1,176 @@
+"""Parse OpenPositions out of an IBKR Flex XML response and join with
+the screen mart so each holding shows current ratio + exit-trigger.
+
+Expected Flex query setup (in IBKR portal):
+  - Section: "Open Positions"
+  - Default fields are fine; we read symbol/description/position/markPrice/
+    costBasisPrice/currency/isin and tolerate missing optional fields.
+
+Symbol mapping: IBKR returns 4-digit Japanese tickers (e.g., "5363"),
+our DB uses 5-digit with trailing 0 (e.g., "53630"). The mapping is a
+simple zfill-and-suffix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from xml.etree import ElementTree as ET
+
+import pandas as pd
+from sqlalchemy import text
+
+
+@dataclass(frozen=True)
+class Position:
+    account_id: str
+    symbol: str            # IBKR's symbol as reported (e.g. "5363")
+    sec_code: str          # 5-digit DB code (e.g. "53630")
+    description: str
+    isin: str | None
+    currency: str
+    quantity: float
+    cost_basis: float | None       # per-share
+    mark_price: float | None
+    unrealized_pl: float | None
+
+
+def ibkr_to_sec_code(symbol: str) -> str:
+    """4-digit IBKR ticker → 5-digit DB code. Already-5-digit stays."""
+    s = symbol.strip()
+    if len(s) == 4 and s.isdigit():
+        return s + "0"
+    return s
+
+
+def _f(s: str | None) -> float | None:
+    if s is None or s == "":
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def parse_open_positions(root: ET.Element) -> list[Position]:
+    """Walk the Flex XML and yield Position rows. Tolerates the common
+    structures (FlexQueryResponse → FlexStatements → FlexStatement →
+    OpenPositions → OpenPosition)."""
+    positions: list[Position] = []
+    for op in root.iter("OpenPosition"):
+        symbol = (op.attrib.get("symbol") or "").strip()
+        if not symbol:
+            continue
+        positions.append(
+            Position(
+                account_id=op.attrib.get("accountId", ""),
+                symbol=symbol,
+                sec_code=ibkr_to_sec_code(symbol),
+                description=op.attrib.get("description", ""),
+                isin=op.attrib.get("isin") or None,
+                currency=op.attrib.get("currency", ""),
+                quantity=float(op.attrib.get("position", "0") or 0),
+                cost_basis=_f(op.attrib.get("costBasisPrice")),
+                mark_price=_f(op.attrib.get("markPrice")),
+                unrealized_pl=_f(op.attrib.get("fifoPnlUnrealized")),
+            )
+        )
+    return positions
+
+
+def enrich_with_screen(engine, positions: list[Position]) -> pd.DataFrame:
+    """Join positions with the latest screen metrics so each holding
+    shows ratio / PER / op_yield / momentum / Q+T flags / exit-trigger
+    state. Stocks not in our DB get NaN columns and are flagged."""
+    if not positions:
+        return pd.DataFrame()
+    pos_df = pd.DataFrame([p.__dict__ for p in positions])
+    codes = pos_df["sec_code"].tolist()
+
+    HAIRCUT = 0.7
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                WITH visible AS (
+                    SELECT fa."secCode" sec_code, fa.period_end,
+                           fa.current_assets, fa.total_liabilities,
+                           fa.investment_securities, fa.operating_income,
+                           fa.net_sales, fa.net_income, fa.issued_shares,
+                           fa.source_doc_id
+                    FROM t_financials_annual fa
+                    JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+                    WHERE dl."submitDateTime"::date <= CURRENT_DATE
+                      AND fa.current_assets IS NOT NULL
+                      AND fa."secCode" = ANY(:codes)
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (sec_code) * FROM visible
+                    ORDER BY sec_code, period_end DESC
+                ),
+                ranked AS (
+                    SELECT fa2."secCode", fa2.period_end,
+                           fa2.operating_income, fa2.net_sales,
+                           LAG(fa2.operating_income) OVER w op_prev,
+                           LAG(fa2.net_sales)        OVER w sales_prev
+                    FROM t_financials_annual fa2
+                    JOIN t_doc_list dl2 ON dl2."docID"=fa2.source_doc_id
+                    WHERE dl2."submitDateTime"::date <= CURRENT_DATE
+                      AND fa2."secCode" = ANY(:codes)
+                    WINDOW w AS (PARTITION BY fa2."secCode" ORDER BY fa2.period_end)
+                ),
+                yoy AS (
+                    SELECT DISTINCT ON ("secCode") "secCode" sec_code, op_prev, sales_prev
+                    FROM ranked WHERE op_prev IS NOT NULL OR sales_prev IS NOT NULL
+                    ORDER BY "secCode", period_end DESC
+                )
+                SELECT l.sec_code, l.current_assets, l.total_liabilities,
+                       l.investment_securities, l.operating_income,
+                       l.net_sales, l.net_income, l.issued_shares,
+                       l.period_end,
+                       y.op_prev, y.sales_prev,
+                       d.adj_close db_price, d."marketCap" mc,
+                       d6.adj_close p_6mo
+                FROM latest l
+                JOIN LATERAL (
+                    SELECT adj_close, "marketCap" FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code
+                      AND p.adj_close IS NOT NULL AND p."marketCap" IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT adj_close FROM t_daily_stock_perf p
+                    WHERE p."ShokenCode" = l.sec_code
+                      AND p."Date" <= CURRENT_DATE - INTERVAL '160 days'
+                      AND p."Date" >= CURRENT_DATE - INTERVAL '200 days'
+                      AND p.adj_close IS NOT NULL
+                    ORDER BY p."Date" DESC LIMIT 1
+                ) d6 ON TRUE
+                LEFT JOIN yoy y ON y.sec_code = l.sec_code
+                """
+            ),
+            {"codes": codes},
+        ).fetchall()
+
+    cols = ["sec_code", "current_assets", "total_liabilities",
+            "investment_securities", "operating_income", "net_sales", "net_income",
+            "issued_shares", "period_end", "op_prev", "sales_prev",
+            "db_price", "mc", "p_6mo"]
+    fund = pd.DataFrame(rows, columns=cols)
+    for c in [c for c in cols if c not in ("sec_code", "period_end")]:
+        fund[c] = pd.to_numeric(fund[c], errors="coerce")
+
+    fund["ratio"] = (
+        fund["current_assets"] - fund["total_liabilities"]
+        + HAIRCUT * fund["investment_securities"].fillna(0)
+    ) / fund["mc"]
+    fund["per"] = fund["mc"] / fund["net_income"]
+    fund["op_yield"] = fund["operating_income"] / fund["mc"]
+    fund["op_yoy"] = (fund["operating_income"] - fund["op_prev"]) / fund["op_prev"].abs()
+    fund["sales_yoy"] = (fund["net_sales"] - fund["sales_prev"]) / fund["sales_prev"]
+    fund["mom_6m"] = fund["db_price"] / fund["p_6mo"] - 1
+    fund["q_flag"] = (fund["op_yield"] > 0.05) & (fund["mom_6m"] > 0)
+    fund["t_flag"] = (fund["op_yoy"] > 0.20) & (fund["sales_yoy"] > 0)
+
+    merged = pos_df.merge(fund, on="sec_code", how="left")
+    merged["exit_triggered"] = merged["ratio"] < 1.0
+    return merged

--- a/src/stock_screening/ibkr/positions.py
+++ b/src/stock_screening/ibkr/positions.py
@@ -35,8 +35,15 @@ class Position:
 
 
 def ibkr_to_sec_code(symbol: str) -> str:
-    """4-digit IBKR ticker → 5-digit DB code. Already-5-digit stays."""
+    """IBKR ticker → 5-digit DB code.
+
+    IBKR returns Japanese symbols as e.g. "5363.T" (TSE suffix). Strip
+    the exchange suffix and pad 4-digit tickers with a trailing 0.
+    """
     s = symbol.strip()
+    # Strip exchange suffix after a dot (e.g. ".T" for TSE).
+    if "." in s:
+        s = s.split(".", 1)[0]
     if len(s) == 4 and s.isdigit():
         return s + "0"
     return s

--- a/tests/test_ibkr_positions.py
+++ b/tests/test_ibkr_positions.py
@@ -1,0 +1,92 @@
+"""Parser tests for IBKR Flex OpenPositions XML — no live API calls."""
+
+from __future__ import annotations
+
+from xml.etree import ElementTree as ET
+
+from stock_screening.ibkr.positions import ibkr_to_sec_code, parse_open_positions
+
+
+SAMPLE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<FlexQueryResponse queryName="positions" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="20260427" toDate="20260427">
+      <OpenPositions>
+        <OpenPosition accountId="U1234567" symbol="5363" description="TOKYO YOGYO CO LTD"
+                      isin="JP3681400003" currency="JPY" position="100"
+                      markPrice="2350" costBasisPrice="2230"
+                      fifoPnlUnrealized="12000.0"/>
+        <OpenPosition accountId="U1234567" symbol="4231" description="TIGERS POLYMER CORP"
+                      isin="JP3679400000" currency="JPY" position="200"
+                      markPrice="1180" costBasisPrice="950"
+                      fifoPnlUnrealized="46000.0"/>
+        <OpenPosition accountId="U1234567" symbol="6137" description="KOIKE SANSO KOGYO"
+                      isin="JP3284000005" currency="JPY" position="50"
+                      markPrice="1850" costBasisPrice="1700"
+                      fifoPnlUnrealized="7500.0"/>
+      </OpenPositions>
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>
+"""
+
+
+def test_ibkr_to_sec_code_pads_4_digit():
+    assert ibkr_to_sec_code("5363") == "53630"
+    assert ibkr_to_sec_code("4231") == "42310"
+
+
+def test_ibkr_to_sec_code_passthrough_5_digit():
+    assert ibkr_to_sec_code("53630") == "53630"
+
+
+def test_ibkr_to_sec_code_handles_whitespace():
+    assert ibkr_to_sec_code("  5363  ") == "53630"
+
+
+def test_parse_open_positions_extracts_all_rows():
+    root = ET.fromstring(SAMPLE_XML)
+    positions = parse_open_positions(root)
+    assert len(positions) == 3
+
+    p = positions[0]
+    assert p.symbol == "5363"
+    assert p.sec_code == "53630"
+    assert p.description == "TOKYO YOGYO CO LTD"
+    assert p.currency == "JPY"
+    assert p.quantity == 100.0
+    assert p.cost_basis == 2230.0
+    assert p.mark_price == 2350.0
+    assert p.unrealized_pl == 12000.0
+    assert p.account_id == "U1234567"
+    assert p.isin == "JP3681400003"
+
+
+def test_parse_open_positions_handles_missing_optional_fields():
+    xml = """<?xml version="1.0"?>
+    <FlexQueryResponse>
+      <OpenPositions>
+        <OpenPosition symbol="9999" description="X" currency="JPY" position="10"/>
+      </OpenPositions>
+    </FlexQueryResponse>"""
+    root = ET.fromstring(xml)
+    positions = parse_open_positions(root)
+    assert len(positions) == 1
+    p = positions[0]
+    assert p.cost_basis is None
+    assert p.mark_price is None
+    assert p.unrealized_pl is None
+    assert p.isin is None
+    assert p.account_id == ""  # missing attr → empty string
+
+
+def test_parse_open_positions_skips_blank_symbol():
+    xml = """<?xml version="1.0"?>
+    <FlexQueryResponse>
+      <OpenPositions>
+        <OpenPosition symbol="" position="10"/>
+        <OpenPosition position="10"/>
+      </OpenPositions>
+    </FlexQueryResponse>"""
+    root = ET.fromstring(xml)
+    assert parse_open_positions(root) == []

--- a/tests/test_ibkr_positions.py
+++ b/tests/test_ibkr_positions.py
@@ -44,6 +44,12 @@ def test_ibkr_to_sec_code_handles_whitespace():
     assert ibkr_to_sec_code("  5363  ") == "53630"
 
 
+def test_ibkr_to_sec_code_strips_exchange_suffix():
+    assert ibkr_to_sec_code("5363.T") == "53630"
+    assert ibkr_to_sec_code("4231.T") == "42310"
+    assert ibkr_to_sec_code("6137.T") == "61370"
+
+
 def test_parse_open_positions_extracts_all_rows():
     root = ET.fromstring(SAMPLE_XML)
     positions = parse_open_positions(root)

--- a/tests/test_trade_plan.py
+++ b/tests/test_trade_plan.py
@@ -1,0 +1,80 @@
+"""Pure-logic tests for the trade plan generator (no DB / no API)."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+# Import the script as a module so we can test its helpers.
+_path = Path(__file__).resolve().parents[1] / "scripts" / "generate_trade_plan.py"
+trade_plan = SourceFileLoader("trade_plan", str(_path)).load_module()
+
+
+def test_limit_price_rounds_up_with_buffer():
+    # 1317 * 1.005 = 1323.585 → 1324
+    assert trade_plan.limit_price(1317.0) == 1324
+    # 526 * 1.005 = 528.63 → 529
+    assert trade_plan.limit_price(526.0) == 529
+    # 932 * 1.005 = 936.66 → 937
+    assert trade_plan.limit_price(932.0) == 937
+
+
+def test_best_deployment_picks_highest_flag_count_within_budget():
+    # 3 candidates: A is Q+T but expensive; B is Q+T and affordable; C is Q only.
+    # Should pick B (top flag count, fits budget).
+    targets = pd.DataFrame([
+        {"sec_code": "A", "name": "A Inc", "price_now": 2000.0, "ratio": 4.0,
+         "per": 5.0, "q_flag": True, "t_flag": True},
+        {"sec_code": "B", "name": "B Inc", "price_now": 1300.0, "ratio": 3.0,
+         "per": 4.0, "q_flag": True, "t_flag": True},
+        {"sec_code": "C", "name": "C Inc", "price_now": 900.0, "ratio": 5.0,
+         "per": 3.0, "q_flag": True, "t_flag": False},
+    ])
+    plan = trade_plan.best_deployment(135_000, targets, current_codes=set())
+    assert plan is not None
+    assert plan["sec_code"] == "B"
+
+
+def test_best_deployment_skips_already_held():
+    targets = pd.DataFrame([
+        {"sec_code": "A", "name": "A Inc", "price_now": 1000.0, "ratio": 5.0,
+         "per": 4.0, "q_flag": True, "t_flag": True},
+        {"sec_code": "B", "name": "B Inc", "price_now": 1100.0, "ratio": 3.0,
+         "per": 4.0, "q_flag": True, "t_flag": False},
+    ])
+    plan = trade_plan.best_deployment(150_000, targets, current_codes={"A"})
+    assert plan is not None
+    assert plan["sec_code"] == "B"
+
+
+def test_best_deployment_returns_none_when_budget_too_small():
+    targets = pd.DataFrame([
+        {"sec_code": "A", "name": "A Inc", "price_now": 5000.0, "ratio": 3.0,
+         "per": 5.0, "q_flag": True, "t_flag": True},
+    ])
+    plan = trade_plan.best_deployment(100_000, targets, current_codes=set())
+    assert plan is None
+
+
+def test_best_deployment_tiebreak_by_ratio_then_flag_count():
+    # Two Q+T picks both fit — higher ratio wins.
+    targets = pd.DataFrame([
+        {"sec_code": "A", "name": "A Inc", "price_now": 1000.0, "ratio": 2.0,
+         "per": 5.0, "q_flag": True, "t_flag": True},
+        {"sec_code": "B", "name": "B Inc", "price_now": 1100.0, "ratio": 5.0,
+         "per": 4.0, "q_flag": True, "t_flag": True},
+    ])
+    plan = trade_plan.best_deployment(200_000, targets, current_codes=set())
+    assert plan is not None
+    assert plan["sec_code"] == "B"
+
+
+def test_best_deployment_returns_none_when_all_held():
+    targets = pd.DataFrame([
+        {"sec_code": "A", "name": "A", "price_now": 1000.0, "ratio": 3.0,
+         "per": 5.0, "q_flag": True, "t_flag": True},
+    ])
+    plan = trade_plan.best_deployment(200_000, targets, current_codes={"A"})
+    assert plan is None


### PR DESCRIPTION
## Summary

Adds `docs/screen_summary.md` — a single-page reference consolidating
the latest backtest results and the current candidate list from the
sweet-spot screen criteria.

Companion to `docs/analysis_notes.md` (which has the deeper rationale
for formula and filter choices).

## What's in it

- **Screening criteria**: ¥3-50B mc + ratio>1.5 + PER ≤ 10
- **Backtest comparison table** (old / wider / sweet-spot configs;
  sweet-spot landed at +76.6% mean vs TOPIX +82.4% over 3 years)
- **Top 12 winners** from the 2022 cohort backtest
- **Today's 29 candidates** organized by signal flags:
  - 🏆 3 names passing both quality + turnaround (大日精化, 小池酸素, 虹技)
  - 💎 9 quality-only
  - 🔄 5 turnaround-only
  - 12 raw value plays without supporting catalysts
- **Caveats**: look-ahead bias, IFRS reporter gap, financial-sector
  concept gap, survivorship bias, single-period limitation
- **Reproduction snippets** for the live screen and backtest

## Notes

- Depends on PR #5 being merged for the backtest script + net_income
  column to exist on `main`. The doc itself is self-contained
  (results are baked into the markdown, not generated on view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)