### PR TITLE
DAGs: bump start_date to home-server deployment cutover

### DIFF
--- a/airflow/dags/edinet_doclist_dag.py
+++ b/airflow/dags/edinet_doclist_dag.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 @dag(
     dag_id="edinet_doclist_dag",
     description="Fetch EDINET filings list for the run date; upsert into t_doc_list.",
-    start_date=datetime(2025, 4, 1, tzinfo=JST),
+    start_date=datetime(2026, 5, 1, tzinfo=JST),
     schedule="0 22 * * *",  # 22:00 JST — well after typical filing windows
     catchup=True,
     max_active_runs=4,

--- a/airflow/dags/edinet_xbrl_ingest_dag.py
+++ b/airflow/dags/edinet_xbrl_ingest_dag.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
         "For filings submitted on the run date: download XBRL bundles, "
         "parse facts → t_financials, refresh latest-flag and annual mart."
     ),
-    start_date=datetime(2025, 4, 1, tzinfo=JST),
+    start_date=datetime(2026, 5, 1, tzinfo=JST),
     schedule="30 22 * * *",  # 30 min after doclist
     catchup=True,
     max_active_runs=4,

--- a/airflow/dags/jquants_daily_prices_dag.py
+++ b/airflow/dags/jquants_daily_prices_dag.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 @dag(
     dag_id="jquants_daily_prices_dag",
     description="JQuants v2 daily_quotes → t_daily_stock_perf.",
-    start_date=datetime(2025, 4, 1, tzinfo=JST),
+    start_date=datetime(2026, 5, 1, tzinfo=JST),
     schedule="0 17 * * 1-5",
     catchup=True,
     max_active_runs=4,

--- a/airflow/dags/paper_trading_sim_dag.py
+++ b/airflow/dags/paper_trading_sim_dag.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 @dag(
     dag_id="paper_trading_sim_dag",
     description="Multi-strategy paper portfolio against the net-cash-ratio screen.",
-    start_date=datetime(2025, 4, 1, tzinfo=JST),
+    start_date=datetime(2026, 5, 1, tzinfo=JST),
     schedule="0 19 * * 1-5",
     catchup=True,
     max_active_runs=1,

--- a/airflow/dags/value_screen_dag.py
+++ b/airflow/dags/value_screen_dag.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 @dag(
     dag_id="value_screen_dag",
     description="Net-cash-ratio screen → t_screen_results.",
-    start_date=datetime(2025, 4, 1, tzinfo=JST),
+    start_date=datetime(2026, 5, 1, tzinfo=JST),
     schedule="0 18 * * 1-5",  # 18:00 JST weekdays — after prices DAG
     catchup=True,
     max_active_runs=4,


### PR DESCRIPTION
## Summary

Single-purpose change: set every DAG's `start_date` to **2026-05-01** (the day the home-server stack came online).

## Why

The home server's fresh airflow metadata DB had no DagRun history. With the previous `start_date=2025-04-01` and `catchup=True`, the scheduler would have created ~1,400 historical DagRuns (5 DAGs × ~280-395 daily slots) and tried to execute them. Idempotent or not, that's:
- Hours of needless compute
- Re-hitting EDINET (rate-limited) and JQuants APIs to upsert data that's already on the server (we transferred it via `pg_dump`)
- Workarounds (mark-success backfill) only worked partially because `edinet_xbrl_ingest_dag` uses dynamic task mapping, which Airflow's mark-success path doesn't fully support

This commit aligns Airflow's view of "when did this DAG start existing" with reality on the new deployment. `catchup=True` is preserved so a future missed tick (laptop/scheduler down) still gets re-run — just no backfill into dates before the server existed.

## Deployment

```bash
ssh shinkato@192.168.68.52 'cd ~/workspace/stock_screening && git pull && cd airflow && docker compose restart scheduler'
```

After that, also clean up the 8 stale `edinet_xbrl_ingest_dag` rows from the failed mark-success attempts (they reference dates before the new start_date so they're inert, but worth removing for cleanliness).

## Test plan

- [x] `grep start_date airflow/dags/*.py` confirms 5/5 files updated
- [ ] Post-deploy: `airflow dags next-execution <each DAG>` should show next run as today's first scheduled time (17:00 / 18:00 / 19:00 / 22:00 / 22:30 JST per existing schedules)
- [ ] Post-deploy: no DagRuns should be created for any date < 2026-05-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)