### PR TITLE
Fix jquants DAG: drop NaN-volume rows + reliable NaN→None

### DIFF
--- a/airflow/dags/jquants_daily_prices_dag.py
+++ b/airflow/dags/jquants_daily_prices_dag.py
@@ -81,7 +81,12 @@ def jquants_daily_prices_dag():
         ).round().astype("Int64")
 
         cols = ("Date", "ShokenCode", "close", "volume", "marketCap")
-        rows = merged[list(cols)].where(pd.notna(merged[list(cols)]), None).to_dict("records")
+        # Drop rows where close or volume is NaN — JQuants returns NaN
+        # for halted / non-trading issues on the date, and bigint columns
+        # reject NaN. Casting to object first lets us replace NaN with
+        # None reliably for the marketCap column (Int64 with <NA>).
+        upsert_df = merged[list(cols)].dropna(subset=["close", "volume"])
+        rows = upsert_df.astype(object).where(pd.notna(upsert_df), None).to_dict("records")
 
         col_list = ", ".join(f'"{c}"' for c in cols)
         placeholders = ", ".join(f":{c}" for c in cols)


### PR DESCRIPTION
## Summary

Second bug surfaced after PR #12 fix landed. JQuants returns NaN close/volume for stocks that didn't trade on the date (halts, etc.). The DAG's existing `.where(pd.notna(...), None)` doesn't actually replace NaN→None for numeric dtypes — pandas keeps NaN as np.nan. Postgres rejects NaN in the bigint volume column with a slightly misleading "bigint out of range" error.

## Diagnostic

Ran the calculation against JQuants 2026-05-01 directly to verify:
- max marketCap is 4.7e13 (Mitsubishi UFJ) — well under bigint max
- max volume 230M — well under bigint max
- top 5 issued_shares all reasonable
- → values are fine, the issue is NaN itself failing bigint coercion

## Fix

1. `dropna(subset=["close", "volume"])` — if the stock didn't trade, drop the row (no useful information to upsert)
2. `.astype(object).where(pd.notna(...), None)` — cast to object first so NaN→None replacement works on remaining columns (e.g. marketCap is None for stocks without fundamentals data)

## Test plan

- [ ] Post-deploy: clear and re-run 2026-05-01 jquants task; expect success and ~4400 prices in `t_daily_stock_perf` for that date
- [ ] No regression for normal-day data

🤖 Generated with [Claude Code](https://claude.com/claude-code)