### PR TITLE
Fix daily report empty: persist adj_close + hydrate IBKR Variables

### DIFF
--- a/airflow/dags/_alerts.py
+++ b/airflow/dags/_alerts.py
@@ -40,6 +40,8 @@ def _hydrate_env_from_variables() -> None:
         "TELEGRAM_BOT_TOKEN",
         "TELEGRAM_CHAT_ID",
         "TELEGRAM_DIAGNOSIS_ENABLED",
+        "IBKR_FLEX_TOKEN",
+        "IBKR_POSITIONS_QUERY_ID",
     ):
         if name not in os.environ:
             try:

--- a/airflow/dags/jquants_daily_prices_dag.py
+++ b/airflow/dags/jquants_daily_prices_dag.py
@@ -57,11 +57,24 @@ def jquants_daily_prices_dag():
             logger.info("no quotes for %s (likely non-trading day)", run_date)
             return 0
 
-        # v2 uses C / Vo for close / volume; collapse 5-digit market codes
-        # to 4-digit secCode (last digit is a check digit added by JPX).
-        quotes = quotes.rename(columns={"Code": "ShokenCode", "C": "close", "Vo": "volume"})
+        # v2 column names: C/Vo = raw close/volume, AdjC/AdjFactor =
+        # corporate-action-adjusted close + factor. The screen's
+        # momentum_6m filter reads adj_close, so this DAG must persist
+        # both — without adj_close, the screen zero-qualifies every
+        # stock for any day this DAG fills.
+        quotes = quotes.rename(columns={
+            "Code": "ShokenCode",
+            "C": "close",
+            "Vo": "volume",
+            "AdjC": "adj_close",
+            "AdjFactor": "adj_factor",
+        })
         quotes["ShokenCode"] = quotes["ShokenCode"].astype(str)
-        quotes_subset = quotes[["ShokenCode", "close", "volume"]].copy()
+        keep_cols = ["ShokenCode", "close", "volume"]
+        for c in ("adj_close", "adj_factor"):
+            if c in quotes.columns:
+                keep_cols.append(c)
+        quotes_subset = quotes[keep_cols].copy()
 
         engine = db.get_engine()
         # pd.read_sql with a SQLAlchemy text() expression is broken under
@@ -86,12 +99,18 @@ def jquants_daily_prices_dag():
             merged["close"].astype("float64") * merged["issued_shares"].astype("float64")
         ).round().astype("Int64")
 
-        cols = ("Date", "ShokenCode", "close", "volume", "marketCap")
+        cols = ["Date", "ShokenCode", "close", "volume", "marketCap"]
+        # Optionally include adj_close / adj_factor when JQuants returned
+        # them. They're present on most days but missing on some
+        # (e.g. when the corporate-action calendar is empty).
+        for c in ("adj_close", "adj_factor"):
+            if c in merged.columns:
+                cols.append(c)
         # Drop rows where close or volume is NaN — JQuants returns NaN
         # for halted / non-trading issues on the date, and bigint columns
         # reject NaN. Casting to object first lets us replace NaN with
         # None reliably for the marketCap column (Int64 with <NA>).
-        upsert_df = merged[list(cols)].dropna(subset=["close", "volume"])
+        upsert_df = merged[cols].dropna(subset=["close", "volume"])
         rows = upsert_df.astype(object).where(pd.notna(upsert_df), None).to_dict("records")
 
         col_list = ", ".join(f'"{c}"' for c in cols)


### PR DESCRIPTION
## Summary

First real daily report (5/8 03:30 JST) arrived with two empty sections:

```
💼 Positions: (IBKR Flex not configured on this host)
🆕 New screen entrants (0):
  (none — universe unchanged from prior session)
Total qualifying today: 0
```

Two distinct bugs.

## Bug 1: 0 qualifying screen results

5/7 had **3,701 stocks scored, 289 passing ratio≥1.0, but 0 qualifying.** Root cause: `airflow/dags/jquants_daily_prices_dag.py` was renaming only `C → close`, `Vo → volume`, silently dropping `AdjC` and `AdjFactor` from JQuants. The screen's momentum_6m filter reads `adj_close`, so without it `(momentum_6m > 0)` is always NaN→False.

`scripts/backfill_window.py` correctly persists `adj_close` / `adj_factor`; the DAG was missed. **Verified by query:** 5/1 prices (filled by manual backfill) have adj_close set on all 4,207 rows; 5/7 prices (filled by DAG) have adj_close NULL on all 4,256 rows.

## Bug 2: IBKR Flex section blank

`IBKR_FLEX_TOKEN` and `IBKR_POSITIONS_QUERY_ID` are in `.env` but not surfaced to airflow workers. Same Variable-vs-env-var pattern as the Telegram creds — register as Airflow Variables and extend `_hydrate_env_from_variables()` to mirror them into `os.environ`.

## Fix

| File | Change |
|---|---|
| `airflow/dags/jquants_daily_prices_dag.py` | Rename `AdjC → adj_close` and `AdjFactor → adj_factor`; append to upsert columns when present (JQuants doesn't always return them, so guard with `if c in quotes.columns`) |
| `airflow/dags/_alerts.py` | Add `IBKR_FLEX_TOKEN` and `IBKR_POSITIONS_QUERY_ID` to the hydration list |
| _Airflow Variables_ (already set on server) | `IBKR_FLEX_TOKEN`, `IBKR_POSITIONS_QUERY_ID` |

## Backfill needed

After merge, the existing 5/7 price rows need their adj_close re-populated. Either:
- Clear and re-run `jquants_daily_prices_dag` for `scheduled__2026-05-07T08:00:00` (now that the DAG writes adj_close)
- Or run `scripts/backfill_window.py 2026-05-07 2026-05-07 --phase=prices`

The 5/8 weekday-evening run should produce a non-empty daily report regardless.

## Test plan

- [x] All 58 tests pass
- [x] All 7 DAG files parse cleanly
- [ ] After merge + 5/7 backfill: query `SELECT COUNT(*) FILTER (WHERE adj_close IS NOT NULL) FROM t_daily_stock_perf WHERE "Date"='2026-05-07'` returns 4,256
- [ ] After 5/8 19:30 JST daily report: positions block populated and "Total qualifying today" > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)