### PR TITLE
Daily report: show strict strategy cohort, drop loose count

### DIFF
--- a/airflow/dags/daily_telegram_report_dag.py
+++ b/airflow/dags/daily_telegram_report_dag.py
@@ -18,9 +18,9 @@ import logging
 import sys
 from datetime import datetime, timedelta
 
+import pandas as pd
 import pendulum
 from airflow.decorators import dag, task
-from sqlalchemy import text
 
 sys.path.insert(0, "/opt/airflow/dags")
 from _alerts import _hydrate_env_from_variables, alert_on_failure  # noqa: E402
@@ -54,67 +54,38 @@ def daily_telegram_report_dag():
 
     @task
     def build_and_send(data_interval_end=None):
+        from stock_screening.screening.metrics import compute_strict_cohort
+
         _hydrate_env_from_variables()
         run_date = (data_interval_end or pendulum.now(JST)).date()
         engine = db.get_engine()
 
-        # New entrants = sweet-spot today minus sweet-spot yesterday.
-        # Use the t_screen_results table that the value_screen_dag writes.
-        with engine.connect() as conn:
-            today_codes = {
-                r[0]
-                for r in conn.execute(
-                    text(
-                        'SELECT "secCode" FROM t_screen_results '
-                        'WHERE run_date = :d AND qualifies = TRUE'
-                    ),
-                    {"d": run_date},
-                ).fetchall()
-            }
-            prev_codes = set()
-            for back in (1, 2, 3):
-                prev_d = run_date - timedelta(days=back)
-                rows = conn.execute(
-                    text(
-                        'SELECT "secCode" FROM t_screen_results '
-                        'WHERE run_date = :d AND qualifies = TRUE'
-                    ),
-                    {"d": prev_d},
-                ).fetchall()
-                if rows:
-                    prev_codes = {r[0] for r in rows}
-                    break
-            new_entrants = sorted(today_codes - prev_codes)
+        # The strict strategy cohort (cap ¥3-30B + ratio>1.5 + PER<=10
+        # + lowest-float-33% overlay, per docs/STRATEGY.md). This is
+        # the set the user actually buys from — much narrower than the
+        # loose "qualifies" pre-filter in t_screen_results.
+        cohort_today = compute_strict_cohort(engine, run_date)
 
-            entrant_details = []
-            if new_entrants:
-                rows = conn.execute(
-                    text(
-                        'SELECT "secCode", ratio, market_cap '
-                        'FROM t_screen_results WHERE run_date = :d '
-                        'AND "secCode" = ANY(:codes) '
-                        'ORDER BY ratio DESC'
-                    ),
-                    {"d": run_date, "codes": list(new_entrants)},
-                ).fetchall()
-                for sc, ratio, mc in rows:
-                    name_row = conn.execute(
-                        text(
-                            'SELECT "filerName" FROM t_doc_list '
-                            'WHERE "secCode" = :c '
-                            'ORDER BY "submitDateTime" DESC LIMIT 1'
-                        ),
-                        {"c": sc},
-                    ).fetchone()
-                    name = name_row[0] if name_row else ""
-                    entrant_details.append(
-                        f"  • {sc} {name[:24]:<24}  ratio={float(ratio):.2f}  "
-                        f"MC=¥{float(mc) / 1e9:.1f}B"
-                    )
+        # Compare to the most recent prior session that produced a
+        # non-empty cohort. Look back up to a week to skip Golden Week
+        # / weekend holes.
+        prev_cohort = pd.DataFrame()
+        prev_d = None
+        for back in range(1, 8):
+            d = run_date - timedelta(days=back)
+            c = compute_strict_cohort(engine, d)
+            if not c.empty:
+                prev_cohort = c
+                prev_d = d
+                break
 
-        # Optional: positions snapshot (skipped if IBKR creds aren't set,
-        # since this DAG also serves as the daily heartbeat even without
-        # broker integration).
+        today_codes = set(cohort_today["sec_code"]) if not cohort_today.empty else set()
+        prev_codes = set(prev_cohort["sec_code"]) if not prev_cohort.empty else set()
+        new_entrants = sorted(today_codes - prev_codes)
+        dropped = sorted(prev_codes - today_codes)
+
+        # Optional: positions snapshot (skipped if IBKR creds aren't
+        # configured; the DAG still serves as the daily heartbeat).
         positions_block = _try_positions_snapshot()
 
         body_parts = [
@@ -122,19 +93,36 @@ def daily_telegram_report_dag():
             "",
             positions_block,
             "",
-            f"🆕 New screen entrants ({len(new_entrants)}):",
+            f"🎯 Strategy cohort ({len(cohort_today)}): "
+            f"sweet-spot ∩ lowest-float-33%",
         ]
-        if entrant_details:
-            body_parts.extend(entrant_details)
+        if cohort_today.empty:
+            body_parts.append("  (none — universe didn't produce any picks today)")
         else:
-            body_parts.append("  (none — universe unchanged from prior session)")
+            for _, r in cohort_today.iterrows():
+                marker = " 🆕" if r["sec_code"] in new_entrants else ""
+                body_parts.append(
+                    f"  {int(r['rank_in_cohort'])}. {r['sec_code']} "
+                    f"{(r['name'] or '')[:24]:<24} "
+                    f"ratio={float(r['ratio']):.2f} "
+                    f"PER={float(r['per']):.1f} "
+                    f"MC=¥{float(r['market_cap'])/1e9:.1f}B"
+                    f"{marker}"
+                )
 
-        body_parts.append("")
-        body_parts.append(f"Total qualifying today: {len(today_codes)}")
+        if dropped:
+            body_parts.append("")
+            body_parts.append(
+                f"📤 Dropped from cohort vs {prev_d.isoformat() if prev_d else '?'}: "
+                f"{', '.join(dropped)}"
+            )
+
         message = "\n".join(p for p in body_parts if p is not None)
         telegram_send(message)
-        logger.info("daily report sent (%d new entrants, %d total)",
-                    len(new_entrants), len(today_codes))
+        logger.info(
+            "daily report sent (cohort=%d, new=%d, dropped=%d, prev_d=%s)",
+            len(cohort_today), len(new_entrants), len(dropped), prev_d,
+        )
 
     build_and_send()
 

--- a/src/stock_screening/screening/metrics.py
+++ b/src/stock_screening/screening/metrics.py
@@ -265,3 +265,111 @@ def compute_turnaround_score(engine: Engine, run_date: date) -> pd.DataFrame:
     df["margin_change"] = margin_now - margin_prev
 
     return df
+
+
+# --- Strict strategy cohort (per docs/STRATEGY.md) ----------------------
+#
+# The looser `compute_screen()` above is a Q-flag-shaped pre-filter
+# (ratio>=1.0 + op_yield>5% + mom_6m>0). The strategy proper layers on
+# tighter cuts: a small-cap band, a higher ratio threshold, a PER cap,
+# and the validated lowest-float-33% overlay. This function returns the
+# final cohort the daily report and trade-plan generator should use.
+
+# Strategy parameters from STRATEGY.md (kept in lock-step).
+STRICT_CAP_MIN = 3_000_000_000
+STRICT_CAP_MAX = 30_000_000_000
+STRICT_RATIO_THRESHOLD = 1.5
+STRICT_PER_MAX = 10.0
+STRICT_FLOAT_PCT = 0.33
+
+
+def compute_strict_cohort(engine: Engine, run_date: date) -> pd.DataFrame:
+    """Return the strict strategy cohort for run_date.
+
+    Columns: sec_code, name, ratio, per, market_cap, issued_shares,
+             rank_in_cohort (1-N by float).
+    The result is the lowest-float STRICT_FLOAT_PCT subset of the
+    sweet-spot universe (cap STRICT_CAP_MIN..MAX + ratio>STRICT_RATIO
+    + 0<PER<=STRICT_PER_MAX), sorted by issued_shares ascending.
+    """
+    sql = text(
+        """
+        WITH latest AS (
+            SELECT DISTINCT ON (fa."secCode")
+                fa."secCode" AS sec_code,
+                fa.current_assets,
+                fa.total_liabilities,
+                fa.investment_securities,
+                fa.net_income,
+                fa.issued_shares
+            FROM t_financials_annual fa
+            JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+            WHERE dl."submitDateTime"::date <= :run_date
+              AND fa.current_assets IS NOT NULL
+              AND fa.issued_shares IS NOT NULL
+            ORDER BY fa."secCode", fa.period_end DESC
+        )
+        SELECT
+            l.sec_code,
+            l.current_assets,
+            l.total_liabilities,
+            l.investment_securities,
+            l.net_income,
+            l.issued_shares,
+            d."marketCap" AS market_cap,
+            (
+                SELECT "filerName" FROM t_doc_list
+                WHERE "secCode" = l.sec_code
+                ORDER BY "submitDateTime" DESC LIMIT 1
+            ) AS name
+        FROM latest l
+        JOIN t_daily_stock_perf d
+          ON d."ShokenCode" = l.sec_code
+         AND d."Date" = :run_date
+         AND d."marketCap" IS NOT NULL
+         AND d."marketCap" > 0
+        """
+    )
+    with engine.connect() as conn:
+        rows = conn.execute(sql, {"run_date": run_date}).fetchall()
+
+    cols = [
+        "sec_code", "current_assets", "total_liabilities",
+        "investment_securities", "net_income", "issued_shares",
+        "market_cap", "name",
+    ]
+    df = pd.DataFrame(rows, columns=cols)
+    if df.empty:
+        return df.assign(ratio=pd.Series(dtype=float), per=pd.Series(dtype=float))
+
+    for c in (
+        "current_assets", "total_liabilities", "investment_securities",
+        "net_income", "issued_shares", "market_cap",
+    ):
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+
+    df["ratio"] = (
+        df["current_assets"].fillna(0)
+        - df["total_liabilities"].fillna(0)
+        + INVESTMENT_SECURITIES_HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["market_cap"]
+    df["per"] = df["market_cap"] / df["net_income"]
+
+    sweet = df[
+        df["market_cap"].between(STRICT_CAP_MIN, STRICT_CAP_MAX)
+        & (df["ratio"] > STRICT_RATIO_THRESHOLD)
+        & (df["per"] > 0)
+        & (df["per"] <= STRICT_PER_MAX)
+    ].copy()
+
+    if sweet.empty:
+        return sweet
+
+    sweet = sweet.sort_values("issued_shares").reset_index(drop=True)
+    n_picks = max(1, int(len(sweet) * STRICT_FLOAT_PCT))
+    cohort = sweet.head(n_picks).copy()
+    cohort["rank_in_cohort"] = range(1, len(cohort) + 1)
+    return cohort[
+        ["sec_code", "name", "ratio", "per", "market_cap",
+         "issued_shares", "rank_in_cohort"]
+    ]


### PR DESCRIPTION
## Summary

User feedback: the daily report's "Total qualifying today: 82" was misleading — that count is the *loose pre-filter* (ratio≥1.0 + op_yield>5% + mom_6m>0), not the strategy you actually buy from (~7 stocks per docs/STRATEGY.md).

This PR makes the report mirror STRATEGY.md exactly.

## Changes

| File | What |
|---|---|
| `src/stock_screening/screening/metrics.py` | New `compute_strict_cohort(engine, run_date)` — applies cap ¥3-30B + ratio>1.5 + 0<PER≤10 + lowest-`STRICT_FLOAT_PCT`-by-issued-shares overlay. Constants kept in lock-step with STRATEGY.md. Returns the cohort named, ranked, with all columns the report needs. |
| `airflow/dags/daily_telegram_report_dag.py` | Replaces the loose-qualifies query with `compute_strict_cohort`. New format: lists each pick (code/name/ratio/PER/MC), marks new entrants with 🆕, shows a "Dropped from cohort" line for any names that fell out vs the prior session. No more loose count. |

## Sample new format

```
📊 Daily report — 2026-05-08

💼 Positions: ...

🎯 Strategy cohort (8): sweet-spot ∩ lowest-float-33%
  1. 46350 東京インキ株式会社             ratio=3.33 PER=3.0 MC=¥3.6B
  2. 56030 虹技株式会社                ratio=1.58 PER=5.6 MC=¥4.5B
  3. 80460 丸藤シートパイル株式会社        ratio=5.63 PER=2.4 MC=¥3.7B 🆕
  ...

📤 Dropped from cohort vs 2026-05-07: 99999
```

## Test plan

- [x] All 58 tests pass
- [x] All 7 DAG files parse cleanly
- [x] `compute_strict_cohort` against local DB for 2026-05-01 returns 8 picks matching the seven listed in screen_summary.md (plus one new entrant since today's sweet-spot universe expanded from 24 to ~25 stocks)
- [ ] Post-deploy: tonight's 19:30 JST run produces a populated cohort message

🤖 Generated with [Claude Code](https://claude.com/claude-code)