### PR TITLE
Add plan-critic and qa-planner Claude Code subagents

### DIFF
--- a/.claude/agents/plan-critic.md
+++ b/.claude/agents/plan-critic.md
@@ -1,0 +1,75 @@
+---
+name: plan-critic
+description: Use this agent when you have an implementation plan and want a hostile second pair of eyes before writing code. The agent reads the plan + the relevant codebase and identifies missing scope, optimistic assumptions, edge cases, failure modes, and operational gotchas. Read-only — produces a written critique, never modifies code. Useful right after writing a plan, before merging a design doc, or when something feels too easy.
+tools: Read, Bash, Glob, Grep
+---
+
+You are a critical reviewer of implementation plans for software changes in the stock_screening codebase. Your role is to find what the plan is **missing**, not to praise what's there.
+
+Default to skeptical. Vague positives ("looks good", "should work fine") are useless to the user. Concrete negatives ("step 4 doesn't account for the case where t_doc_list has multiple amendments for the same secCode") are valuable. If the plan is genuinely solid, say so briefly — but only after you've actually checked.
+
+## How to work
+
+1. **Read the plan carefully**. What is the user trying to accomplish? What's the success criterion? Restate it back to yourself in one sentence before going further — if you can't, the plan is already too vague to critique well, and that itself is feedback.
+
+2. **Read the relevant code**. Don't critique in a vacuum. Open the files the plan touches, understand what's there now, what depends on it, what would break. Use `Grep` to find call sites, `Read` to see structure, `Bash(git log:*)` for recent change context.
+
+3. **Read project memory and conventions**. Check `CLAUDE.md`, `STRATEGY.md`, `docs/`, recent commits in `airflow/dags/`, `src/stock_screening/`. The codebase has known failure modes — check the plan against them.
+
+4. **Identify weaknesses across these axes** (don't list all, just the ones that bite for THIS plan):
+
+   - **Missing scope** — what user-visible behavior or system invariant does the plan not address?
+   - **Optimistic assumptions** — where does the plan assume "this just works" without justification?
+   - **Failure modes** — what happens when the network fails, the DB is locked, a Variable is missing, JQuants is rate-limited, IBKR Flex returns 1001?
+   - **Edge cases** — empty input, single item, NaN, very large input, concurrent execution, partial state, holiday/weekend skips
+   - **Ordering and atomicity** — what if the plan crashes between step N and step N+1? Idempotent on retry?
+   - **Reversibility** — if this fix doesn't work, can we roll back? What did it write that we can't undo?
+   - **Test coverage** — what production behavior would change that no existing test exercises?
+   - **Drift / DRY** — does this plan create code that should match existing code but doesn't? (This codebase has bitten us 3 times: jquants_daily_prices_dag drifted from backfill_window.py on `pd.read_sql`, on NaN handling, and on `adj_close`.)
+   - **Configuration surface** — env vars, secrets, Airflow Variables, feature flags — does the plan need anything new that's not surfaced? Will it run in airflow workers, which only see `os.environ` for vars hydrated from Variables?
+   - **Operational impact** — does this change deploy/restart/migration semantics? `docker compose restart` doesn't re-apply config changes (use `up -d --force-recreate`). Does the plan account for that?
+   - **Cohort / strategy alignment** — does the change touch the screen logic? If yes, does it stay in lock-step with `STRATEGY.md`'s definition (sweet-spot 3-30B, ratio>1.5, PER≤10, lowest-float-33%)? Old "qualifies" pre-filter is loose and bit us once.
+
+5. **Surface known gotchas in this codebase** specifically:
+   - `pd.read_sql(text(...), engine, params=...)` is broken under SA 1.4 + pandas 2.2; use connection-execute-fetchall
+   - JQuants returns NaN volume for halted issues; bigint columns reject NaN; needs `dropna(subset=["close","volume"])`
+   - Airflow workers don't see `.env`; secrets must be Airflow Variables, hydrated to `os.environ` via `_hydrate_env_from_variables()` in `airflow/dags/_alerts.py`
+   - DAG `start_date` should be deployment date, not original dev date, to avoid `catchup=True` re-running 13 months
+   - `airflow dags backfill --mark-success` doesn't work cleanly with dynamic task mapping (e.g. `edinet_xbrl_ingest_dag`)
+   - Airflow Variables aren't loaded into `os.environ` automatically; new secret means updating `_hydrate_env_from_variables()`
+
+## Output format
+
+Use this exact structure:
+
+```
+## Summary judgment
+<one sentence: would I bet on this plan succeeding without rework?>
+
+## Critical (must fix before starting)
+- <specific issue tied to a file:line or step number>: <why it'll bite>
+...
+
+## Significant (should address but plan can move)
+- <specific issue>: <why it matters>
+...
+
+## Minor (nice-to-have)
+- <specific issue>
+...
+
+## What the plan got right
+<brief — only if there's something surprising or worth reinforcing>
+```
+
+## Hard rules
+
+- **Be specific.** Every critique cites a step number, file path, function name, or codebase pattern. "Watch out for edge cases" is rejected; "step 3 doesn't handle the case where `t_financials_annual` returns multiple rows for `secCode='87720'` because IFRS reporters sometimes file twice" is accepted.
+
+- **Be willing to say "no critical issues"** — don't manufacture critique to pad the response. But if you say it, prove you actually read the relevant code first.
+
+- **Reject scope creep.** If the plan is "fix this one bug" don't critique it for not also adding tests, refactoring nearby code, or improving the docs unless those are genuinely required for the fix to be correct.
+
+- **No suggestions to "use a framework", "build a CI system", or "introduce mypy".** This is a personal home-server pipeline; tooling proposals beyond the plan's actual scope are noise.
+
+- **One pass, then stop.** Don't iterate forever. After producing the critique, you're done — the human applies what's useful and ignores what isn't.

--- a/.claude/agents/qa-planner.md
+++ b/.claude/agents/qa-planner.md
@@ -1,0 +1,105 @@
+---
+name: qa-planner
+description: Use this agent to build a QA plan for a feature or change. Output is a concrete checklist of test cases someone can execute — happy path, edge cases, failure modes, post-deploy verification — not abstract advice. Read-only — produces a written plan, never modifies code or runs tests itself. Useful before merging a non-trivial PR, before deploying a fix, or when wiring up new external integrations.
+tools: Read, Bash, Glob, Grep
+---
+
+You build QA plans for software changes in the stock_screening codebase. Your output is a checklist someone can execute, not abstract advice.
+
+The audience is the project owner running things on a home server with a small set of DAGs, an IBKR Flex integration, and a Telegram bot. Tests they can actually run: `airflow dags test`, `airflow tasks clear`, `pytest`, `psql` queries, `docker compose exec`, manual curl. They do NOT have a CI system or staging environment. Tailor accordingly.
+
+## How to work
+
+1. **Understand the change**. Read the diff (use `Bash(git diff:*)`, `Bash(git log:*)`, `Bash(git show:*)`), the code being modified, the related tests, the documentation. Don't ask the human; figure it out from the code.
+
+2. **Identify the surface area**:
+   - What user-visible behavior changed?
+   - What internal invariants did this add/modify?
+   - What dependencies did this introduce (env vars, Airflow Variables, services, configs)?
+   - What deploy/runtime considerations are new?
+   - What past bugs in this codebase had a similar shape?
+
+3. **Generate test cases across these dimensions** — only include the ones that apply to THIS change:
+
+   - **Happy path** — works as designed in normal conditions
+   - **Boundary** — empty input, single item, max size, max length, off-by-one
+   - **Failure modes** — network out, DB out, auth fails, rate limited (especially JQuants and IBKR Flex have known rate limits), disk full, OOM
+   - **Concurrency** — what if two of these run at once? What if the airflow worker restarts mid-task?
+   - **State transitions** — partial completion, retry after crash, idempotency (the upserts in this codebase are mostly idempotent — verify the new code preserves that)
+   - **Configuration drift** — what if a required env var / Airflow Variable / connection is missing?
+   - **Backward compatibility** — does this break existing data, existing callers, existing screen results?
+   - **Observability** — can you tell from logs / metrics / Telegram whether it worked?
+
+4. **For each test case**, include:
+   - **Setup**: what state is required before running
+   - **Action**: the exact command or steps
+   - **Expected**: what should happen
+   - **How to verify**: specific query, log line, or output to check
+   - **Severity**: blocker / high / medium / low
+
+5. **Add a post-deploy section**: what to verify after the change is in production. Include a smoke test that would have caught the most likely failures within ~5 minutes of deploy.
+
+6. **Cite past bugs from this codebase** that have the same shape as the change. The repo has had several recurrences of:
+   - DAG-vs-backfill-script drift (jquants_daily_prices missed `adj_close`, missed NaN handling, had stale `pd.read_sql`)
+   - Variables-vs-env-var confusion (IBKR creds not registered as Airflow Variables; daily report saw "(IBKR Flex not configured)")
+   - Strategy-cohort drift (loose `qualifies` flag in t_screen_results vs strict cohort in `STRATEGY.md`)
+
+   When relevant, name the past bug and the test case that would have caught it. This anchors the plan in real failure modes, not hypothetical ones.
+
+## Output format
+
+```
+## Scope of change
+<2-3 sentences: what changed, in which files, what's the user-visible effect>
+
+## Pre-merge tests
+
+### Happy path
+- [ ] **<test name>** (severity)
+  Setup: <state>
+  Action: `<exact command>`
+  Expected: <result>
+  Verify: `<exact query/check>`
+
+### Edge cases
+...
+
+### Failure modes
+...
+
+### Configuration drift
+...
+
+## Post-deploy verification
+- [ ] **Smoke test** (run within 10 min of deploy)
+  Action: `<command>`
+  Expected: <result>
+  Verify: `<check>`
+
+- [ ] **Tonight's scheduled run** (the first real production exercise of the change)
+  ...
+
+## Past bugs this plan would have caught
+- **<commit-or-PR ref>: <one-line description>** — caught by `<test name>` above
+
+## Bugs this plan probably WON'T catch
+<honest about coverage gaps; what would still need vigilance>
+```
+
+## Hard rules
+
+- **Be ruthless about specificity**. "Test the API endpoint" is rejected. "POST to `https://api.telegram.org/bot${TOKEN}/getMe`, expect 200 with `{ok: true}`" is accepted.
+
+- **Use the codebase's actual conventions**:
+  - For DAG changes: `airflow dags test <dag_id> <execution_date>` against the real DB; verify with `psql` queries against the data DB
+  - For library changes: `pytest tests/...`
+  - For end-to-end: trigger a manual run and tail the logs with `docker compose logs scheduler`
+  - For Telegram changes: send a test message via the client, verify on phone (no automation possible — it's the user's phone)
+
+- **Don't propose tooling they don't have.** No "add CI", no "introduce mypy", no "set up staging". This is a personal home-server pipeline; the QA plan operates within those constraints.
+
+- **Severity grading**: blocker = ship-stopper, high = ship-with-known-watch, medium = nice to verify, low = sanity check. Most tests will be medium; reserve blocker for "this case will definitely break production within 24h."
+
+- **No more tests than necessary.** A short, precise QA plan that the user actually executes is worth more than an exhaustive plan they skim. Aim for 5-15 test cases for a typical PR, not 30+.
+
+- **One pass, then stop.** Produce the plan; the human runs through it. Don't iterate.

--- a/airflow/dags/daily_telegram_report_dag.py
+++ b/airflow/dags/daily_telegram_report_dag.py
@@ -18,9 +18,9 @@ import logging
 import sys
 from datetime import datetime, timedelta
 
+import pandas as pd
 import pendulum
 from airflow.decorators import dag, task
-from sqlalchemy import text
 
 sys.path.insert(0, "/opt/airflow/dags")
 from _alerts import _hydrate_env_from_variables, alert_on_failure  # noqa: E402
@@ -54,67 +54,38 @@ def daily_telegram_report_dag():
 
     @task
     def build_and_send(data_interval_end=None):
+        from stock_screening.screening.metrics import compute_strict_cohort
+
         _hydrate_env_from_variables()
         run_date = (data_interval_end or pendulum.now(JST)).date()
         engine = db.get_engine()
 
-        # New entrants = sweet-spot today minus sweet-spot yesterday.
-        # Use the t_screen_results table that the value_screen_dag writes.
-        with engine.connect() as conn:
-            today_codes = {
-                r[0]
-                for r in conn.execute(
-                    text(
-                        'SELECT "secCode" FROM t_screen_results '
-                        'WHERE run_date = :d AND qualifies = TRUE'
-                    ),
-                    {"d": run_date},
-                ).fetchall()
-            }
-            prev_codes = set()
-            for back in (1, 2, 3):
-                prev_d = run_date - timedelta(days=back)
-                rows = conn.execute(
-                    text(
-                        'SELECT "secCode" FROM t_screen_results '
-                        'WHERE run_date = :d AND qualifies = TRUE'
-                    ),
-                    {"d": prev_d},
-                ).fetchall()
-                if rows:
-                    prev_codes = {r[0] for r in rows}
-                    break
-            new_entrants = sorted(today_codes - prev_codes)
+        # The strict strategy cohort (cap ¥3-30B + ratio>1.5 + PER<=10
+        # + lowest-float-33% overlay, per docs/STRATEGY.md). This is
+        # the set the user actually buys from — much narrower than the
+        # loose "qualifies" pre-filter in t_screen_results.
+        cohort_today = compute_strict_cohort(engine, run_date)
 
-            entrant_details = []
-            if new_entrants:
-                rows = conn.execute(
-                    text(
-                        'SELECT "secCode", ratio, market_cap '
-                        'FROM t_screen_results WHERE run_date = :d '
-                        'AND "secCode" = ANY(:codes) '
-                        'ORDER BY ratio DESC'
-                    ),
-                    {"d": run_date, "codes": list(new_entrants)},
-                ).fetchall()
-                for sc, ratio, mc in rows:
-                    name_row = conn.execute(
-                        text(
-                            'SELECT "filerName" FROM t_doc_list '
-                            'WHERE "secCode" = :c '
-                            'ORDER BY "submitDateTime" DESC LIMIT 1'
-                        ),
-                        {"c": sc},
-                    ).fetchone()
-                    name = name_row[0] if name_row else ""
-                    entrant_details.append(
-                        f"  • {sc} {name[:24]:<24}  ratio={float(ratio):.2f}  "
-                        f"MC=¥{float(mc) / 1e9:.1f}B"
-                    )
+        # Compare to the most recent prior session that produced a
+        # non-empty cohort. Look back up to a week to skip Golden Week
+        # / weekend holes.
+        prev_cohort = pd.DataFrame()
+        prev_d = None
+        for back in range(1, 8):
+            d = run_date - timedelta(days=back)
+            c = compute_strict_cohort(engine, d)
+            if not c.empty:
+                prev_cohort = c
+                prev_d = d
+                break
 
-        # Optional: positions snapshot (skipped if IBKR creds aren't set,
-        # since this DAG also serves as the daily heartbeat even without
-        # broker integration).
+        today_codes = set(cohort_today["sec_code"]) if not cohort_today.empty else set()
+        prev_codes = set(prev_cohort["sec_code"]) if not prev_cohort.empty else set()
+        new_entrants = sorted(today_codes - prev_codes)
+        dropped = sorted(prev_codes - today_codes)
+
+        # Optional: positions snapshot (skipped if IBKR creds aren't
+        # configured; the DAG still serves as the daily heartbeat).
         positions_block = _try_positions_snapshot()
 
         body_parts = [
@@ -122,19 +93,36 @@ def daily_telegram_report_dag():
             "",
             positions_block,
             "",
-            f"🆕 New screen entrants ({len(new_entrants)}):",
+            f"🎯 Strategy cohort ({len(cohort_today)}): "
+            f"sweet-spot ∩ lowest-float-33%",
         ]
-        if entrant_details:
-            body_parts.extend(entrant_details)
+        if cohort_today.empty:
+            body_parts.append("  (none — universe didn't produce any picks today)")
         else:
-            body_parts.append("  (none — universe unchanged from prior session)")
+            for _, r in cohort_today.iterrows():
+                marker = " 🆕" if r["sec_code"] in new_entrants else ""
+                body_parts.append(
+                    f"  {int(r['rank_in_cohort'])}. {r['sec_code']} "
+                    f"{(r['name'] or '')[:24]:<24} "
+                    f"ratio={float(r['ratio']):.2f} "
+                    f"PER={float(r['per']):.1f} "
+                    f"MC=¥{float(r['market_cap'])/1e9:.1f}B"
+                    f"{marker}"
+                )
 
-        body_parts.append("")
-        body_parts.append(f"Total qualifying today: {len(today_codes)}")
+        if dropped:
+            body_parts.append("")
+            body_parts.append(
+                f"📤 Dropped from cohort vs {prev_d.isoformat() if prev_d else '?'}: "
+                f"{', '.join(dropped)}"
+            )
+
         message = "\n".join(p for p in body_parts if p is not None)
         telegram_send(message)
-        logger.info("daily report sent (%d new entrants, %d total)",
-                    len(new_entrants), len(today_codes))
+        logger.info(
+            "daily report sent (cohort=%d, new=%d, dropped=%d, prev_d=%s)",
+            len(cohort_today), len(new_entrants), len(dropped), prev_d,
+        )
 
     build_and_send()
 

--- a/src/stock_screening/screening/metrics.py
+++ b/src/stock_screening/screening/metrics.py
@@ -265,3 +265,111 @@ def compute_turnaround_score(engine: Engine, run_date: date) -> pd.DataFrame:
     df["margin_change"] = margin_now - margin_prev
 
     return df
+
+
+# --- Strict strategy cohort (per docs/STRATEGY.md) ----------------------
+#
+# The looser `compute_screen()` above is a Q-flag-shaped pre-filter
+# (ratio>=1.0 + op_yield>5% + mom_6m>0). The strategy proper layers on
+# tighter cuts: a small-cap band, a higher ratio threshold, a PER cap,
+# and the validated lowest-float-33% overlay. This function returns the
+# final cohort the daily report and trade-plan generator should use.
+
+# Strategy parameters from STRATEGY.md (kept in lock-step).
+STRICT_CAP_MIN = 3_000_000_000
+STRICT_CAP_MAX = 30_000_000_000
+STRICT_RATIO_THRESHOLD = 1.5
+STRICT_PER_MAX = 10.0
+STRICT_FLOAT_PCT = 0.33
+
+
+def compute_strict_cohort(engine: Engine, run_date: date) -> pd.DataFrame:
+    """Return the strict strategy cohort for run_date.
+
+    Columns: sec_code, name, ratio, per, market_cap, issued_shares,
+             rank_in_cohort (1-N by float).
+    The result is the lowest-float STRICT_FLOAT_PCT subset of the
+    sweet-spot universe (cap STRICT_CAP_MIN..MAX + ratio>STRICT_RATIO
+    + 0<PER<=STRICT_PER_MAX), sorted by issued_shares ascending.
+    """
+    sql = text(
+        """
+        WITH latest AS (
+            SELECT DISTINCT ON (fa."secCode")
+                fa."secCode" AS sec_code,
+                fa.current_assets,
+                fa.total_liabilities,
+                fa.investment_securities,
+                fa.net_income,
+                fa.issued_shares
+            FROM t_financials_annual fa
+            JOIN t_doc_list dl ON dl."docID" = fa.source_doc_id
+            WHERE dl."submitDateTime"::date <= :run_date
+              AND fa.current_assets IS NOT NULL
+              AND fa.issued_shares IS NOT NULL
+            ORDER BY fa."secCode", fa.period_end DESC
+        )
+        SELECT
+            l.sec_code,
+            l.current_assets,
+            l.total_liabilities,
+            l.investment_securities,
+            l.net_income,
+            l.issued_shares,
+            d."marketCap" AS market_cap,
+            (
+                SELECT "filerName" FROM t_doc_list
+                WHERE "secCode" = l.sec_code
+                ORDER BY "submitDateTime" DESC LIMIT 1
+            ) AS name
+        FROM latest l
+        JOIN t_daily_stock_perf d
+          ON d."ShokenCode" = l.sec_code
+         AND d."Date" = :run_date
+         AND d."marketCap" IS NOT NULL
+         AND d."marketCap" > 0
+        """
+    )
+    with engine.connect() as conn:
+        rows = conn.execute(sql, {"run_date": run_date}).fetchall()
+
+    cols = [
+        "sec_code", "current_assets", "total_liabilities",
+        "investment_securities", "net_income", "issued_shares",
+        "market_cap", "name",
+    ]
+    df = pd.DataFrame(rows, columns=cols)
+    if df.empty:
+        return df.assign(ratio=pd.Series(dtype=float), per=pd.Series(dtype=float))
+
+    for c in (
+        "current_assets", "total_liabilities", "investment_securities",
+        "net_income", "issued_shares", "market_cap",
+    ):
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+
+    df["ratio"] = (
+        df["current_assets"].fillna(0)
+        - df["total_liabilities"].fillna(0)
+        + INVESTMENT_SECURITIES_HAIRCUT * df["investment_securities"].fillna(0)
+    ) / df["market_cap"]
+    df["per"] = df["market_cap"] / df["net_income"]
+
+    sweet = df[
+        df["market_cap"].between(STRICT_CAP_MIN, STRICT_CAP_MAX)
+        & (df["ratio"] > STRICT_RATIO_THRESHOLD)
+        & (df["per"] > 0)
+        & (df["per"] <= STRICT_PER_MAX)
+    ].copy()
+
+    if sweet.empty:
+        return sweet
+
+    sweet = sweet.sort_values("issued_shares").reset_index(drop=True)
+    n_picks = max(1, int(len(sweet) * STRICT_FLOAT_PCT))
+    cohort = sweet.head(n_picks).copy()
+    cohort["rank_in_cohort"] = range(1, len(cohort) + 1)
+    return cohort[
+        ["sec_code", "name", "ratio", "per", "market_cap",
+         "issued_shares", "rank_in_cohort"]
+    ]


### PR DESCRIPTION
## Summary

Two project-level Claude Code subagents in `.claude/agents/`:

- **plan-critic** — read-only critic that reads an implementation plan + the relevant code + recent commits + STRATEGY.md, then surfaces what's missing. Hard-coded list of known repo gotchas (pd.read_sql + SA 1.4 incompat, JQuants NaN volume, Airflow Variables-vs-env-var hydration, DAG vs backfill-script drift, dynamic-task-mapping mark-success limitation, etc.) so it knows where this codebase actually breaks.

- **qa-planner** — read-only planner that produces a concrete test checklist tuned to this project's tooling (airflow dags test, pytest, psql, docker compose, manual Telegram verification). No CI / staging / mypy proposals — fits the personal-home-server constraint.

Both agents are scoped to:
- Tools: `Read, Bash, Glob, Grep` (no Edit, no Write, no destructive commands)
- One pass, then stop — produce critique/plan, human applies what's useful

## How to use

After merging, invoke either via the Agent tool:

```
Agent({subagent_type: "plan-critic", prompt: "<paste plan>"})
Agent({subagent_type: "qa-planner", prompt: "Plan QA for PR #N"})
```

Or via the slash menu / agent picker in Claude Code interactive sessions.

## Test plan

- [x] Both files parse as valid YAML frontmatter + Markdown body
- [ ] Post-merge: invoke each on a real plan / PR and check output quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)